### PR TITLE
Add support for metron error event envelopes

### DIFF
--- a/datadogclient/datadog_client.go
+++ b/datadogclient/datadog_client.go
@@ -198,7 +198,6 @@ func (c *Client) postEvents() error {
 			c.log.Warn("Cannot format event")
 			continue
 		}
-		c.events = make([]Event, 0)
 
 		if err := c.sendData(eventBytes, c.eventsURL()); err != nil {
 			return err

--- a/datadogclient/datadog_client.go
+++ b/datadogclient/datadog_client.go
@@ -193,8 +193,11 @@ func (c *Client) postEvents() error {
 
 	c.totalMetricsSent += uint64(numEvents)
 	for _, event := range c.events {
-
-		eventBytes := c.formatter.FormatEvent(c.prefix, c.maxPostBytes, event)
+		eventBytes, err := c.formatter.FormatEvent(c.prefix, c.maxPostBytes, event)
+		if err != nil {
+			c.log.Warn("Cannot format event")
+			continue
+		}
 		c.events = make([]Event, 0)
 
 		if err := c.sendData(eventBytes, c.eventsURL()); err != nil {

--- a/datadogclient/datadog_client.go
+++ b/datadogclient/datadog_client.go
@@ -22,6 +22,7 @@ type Client struct {
 	apiURL                string
 	apiKey                string
 	metricPoints          map[MetricKey]MetricValue
+	events                []Event
 	prefix                string
 	deployment            string
 	ip                    string
@@ -56,6 +57,18 @@ type Metric struct {
 	Type   string   `json:"type"`
 	Host   string   `json:"host,omitempty"`
 	Tags   []string `json:"tags,omitempty"`
+}
+
+type Event struct {
+	Title          string   `json:"title"`
+	Text           string   `json:"text"`
+	DateHappened   int64    `json:"date_happened,omitempty"`
+	Host           string   `json:"host,omitempty"`
+	Priority       string   `json:"priority,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	AlertType      string   `json:"alert_type,omitempty"`
+	AggregationKey string   `json:"aggregation_key,omitempty"`
+	SourceTypeName string   `json:"source_type_name,omitempty"`
 }
 
 type Point struct {
@@ -101,12 +114,20 @@ func (c *Client) AlertSlowConsumerError() {
 	c.addInternalMetric("slowConsumerAlert", uint64(1))
 }
 
-func (c *Client) AddMetric(envelope *events.Envelope) {
+func (c *Client) Add(envelope *events.Envelope) {
 	c.totalMessagesReceived++
-	if envelope.GetEventType() != events.Envelope_ValueMetric && envelope.GetEventType() != events.Envelope_CounterEvent {
+
+	switch envelope.GetEventType() {
+	case events.Envelope_CounterEvent, events.Envelope_ValueMetric:
+		c.addMetric(envelope)
+	case events.Envelope_Error:
+		c.addEvent(envelope)
+	default:
 		return
 	}
+}
 
+func (c *Client) addMetric(envelope *events.Envelope) {
 	tags := parseTags(envelope)
 	host := parseHost(envelope)
 
@@ -129,22 +150,54 @@ func (c *Client) AddMetric(envelope *events.Envelope) {
 	c.metricPoints[key] = mVal
 }
 
-func (c *Client) PostMetrics() error {
+func (c *Client) addEvent(envelope *events.Envelope) {
+	title := fmt.Sprintf("%s: %d", envelope.GetError().GetSource(), envelope.GetError().GetCode())
+	event := Event{
+		Title:        title,
+		Text:         envelope.GetError().GetMessage(),
+		DateHappened: envelope.GetTimestamp() / int64(time.Second),
+		Tags:         parseTags(envelope),
+	}
+
+	c.events = append(c.events, event)
+}
+
+func (c *Client) Post() error {
 	c.populateInternalMetrics()
+
+	if err := c.postMetrics(); err != nil {
+		return err
+	}
+
+	if err := c.postEvents(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) postMetrics() error {
 	numMetrics := len(c.metricPoints)
 	c.log.Infof("Posting %d metrics", numMetrics)
 
 	c.totalMetricsSent += uint64(len(c.metricPoints))
-	seriesBytes := c.formatter.Format(c.prefix, c.maxPostBytes, c.metricPoints)
+	seriesBytes := c.formatter.FormatMetrics(c.prefix, c.maxPostBytes, c.metricPoints)
 	c.metricPoints = make(map[MetricKey]MetricValue)
 
-	for _, data := range seriesBytes {
-		if uint32(len(data)) > c.maxPostBytes {
-			c.log.Infof("Throwing out metric that exceeds %d bytes", c.maxPostBytes)
-			continue
-		}
+	return c.sendData(seriesBytes, c.seriesURL())
+}
 
-		if err := c.postMetrics(data); err != nil {
+func (c *Client) postEvents() error {
+	numEvents := len(c.events)
+	c.log.Infof("Posting %d events", numEvents)
+
+	c.totalMetricsSent += uint64(numEvents)
+	for _, event := range c.events {
+
+		eventBytes := c.formatter.FormatEvent(c.prefix, c.maxPostBytes, event)
+		c.events = make([]Event, 0)
+
+		if err := c.sendData(eventBytes, c.eventsURL()); err != nil {
 			return err
 		}
 	}
@@ -152,9 +205,23 @@ func (c *Client) PostMetrics() error {
 	return nil
 }
 
-func (c *Client) postMetrics(seriesBytes []byte) error {
-	url := c.seriesURL()
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(seriesBytes))
+func (c *Client) sendData(data [][]byte, url string) error {
+	for _, chunk := range data {
+		if uint32(len(chunk)) > c.maxPostBytes {
+			c.log.Infof("Throwing out data chunk that exceeds %d bytes", c.maxPostBytes)
+			continue
+		}
+
+		if err := c.send(chunk, url); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) send(data []byte, url string) error {
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -174,7 +241,12 @@ func (c *Client) postMetrics(seriesBytes []byte) error {
 }
 
 func (c *Client) seriesURL() string {
-	url := fmt.Sprintf("%s?api_key=%s", c.apiURL, c.apiKey)
+	url := fmt.Sprintf("%s/series?api_key=%s", c.apiURL, c.apiKey)
+	return url
+}
+
+func (c *Client) eventsURL() string {
+	url := fmt.Sprintf("%s/events?api_key=%s", c.apiURL, c.apiKey)
 	return url
 }
 

--- a/datadogclient/datadog_client_test.go
+++ b/datadogclient/datadog_client_test.go
@@ -347,35 +347,83 @@ var _ = Describe("DatadogClient", func() {
 		validateMetrics(payload, 2, 0)
 	})
 
-	It("posts Error Event in JSON format", func() {
-		c.Add(&events.Envelope{
-			Origin:    proto.String("origin"),
-			Timestamp: proto.Int64(1000000000),
-			EventType: events.Envelope_Error.Enum(),
-			Error: &events.Error{
-				Source:  proto.String("app"),
-				Message: proto.String("application failure"),
-				Code:    proto.Int32(500),
-			},
-			Deployment: proto.String("deployment-name"),
-			Job:        proto.String("doppler"),
+	Context("Error Events", func() {
+		It("posts Error Event in JSON format", func() {
+			c.Add(&events.Envelope{
+				Origin:    proto.String("origin"),
+				Timestamp: proto.Int64(1000000000),
+				EventType: events.Envelope_Error.Enum(),
+				Error: &events.Error{
+					Source:  proto.String("app"),
+					Message: proto.String("application failure"),
+					Code:    proto.Int32(500),
+				},
+				Deployment: proto.String("deployment-name"),
+				Job:        proto.String("doppler"),
+				Tags: map[string]string{
+					"protocol": "http",
+				},
+			})
+
+			err := c.Post()
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(bodies).Should(HaveLen(2))
+
+			var payload datadogclient.Payload
+			err = json.Unmarshal(bodies[0], &payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(payload.Series).To(HaveLen(3))
+
+			var event datadogclient.Event
+			err = json.Unmarshal(bodies[1], &event)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(event.Title).To(Equal("app: 500"))
+			Expect(event.Text).To(Equal("application failure"))
+			Expect(event.Tags).To(Equal([]string{"deployment:deployment-name", "job:doppler", "origin:origin", "name:origin", "protocol:http"}))
 		})
 
-		err := c.Post()
-		Expect(err).ToNot(HaveOccurred())
+		It("posts multiple Error Events in JSON format", func() {
+			c.Add(&events.Envelope{
+				Origin:    proto.String("origin"),
+				Timestamp: proto.Int64(1000000000),
+				EventType: events.Envelope_Error.Enum(),
+				Error: &events.Error{
+					Source:  proto.String("app-one"),
+					Message: proto.String("application failure one"),
+					Code:    proto.Int32(500),
+				},
+				Deployment: proto.String("deployment-name"),
+				Job:        proto.String("doppler"),
+			})
 
-		Eventually(bodies).Should(HaveLen(2))
+			c.Add(&events.Envelope{
+				Origin:    proto.String("origin"),
+				Timestamp: proto.Int64(1000000000),
+				EventType: events.Envelope_Error.Enum(),
+				Error: &events.Error{
+					Source:  proto.String("app-two"),
+					Message: proto.String("application failure two"),
+					Code:    proto.Int32(400),
+				},
+				Deployment: proto.String("deployment-name"),
+				Job:        proto.String("doppler"),
+			})
 
-		eventsFound := false
-		var event datadogclient.Event
-		err = json.Unmarshal(bodies[1], &event)
-		Expect(err).NotTo(HaveOccurred())
+			err := c.Post()
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(bodies).Should(HaveLen(3))
 
-		eventsFound = true
-		Expect(event.Title).To(Equal("app: 500"))
-		Expect(event.Text).To(Equal("application failure"))
-		Expect(event.Tags).To(Equal([]string{"deployment:deployment-name", "job:doppler"}))
-		Expect(eventsFound).To(BeTrue())
+			var event1, event2 datadogclient.Event
+			err = json.Unmarshal(bodies[1], &event1)
+			Expect(err).NotTo(HaveOccurred())
+			err = json.Unmarshal(bodies[2], &event2)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(event1.Title).To(Equal("app-one: 500"))
+			Expect(event2.Title).To(Equal("app-two: 400"))
+		})
 	})
 
 	It("breaks up a message that exceeds the FlushMaxBytes", func() {

--- a/datadogclient/formatter.go
+++ b/datadogclient/formatter.go
@@ -23,10 +23,13 @@ func (f Formatter) FormatMetrics(prefix string, maxPostBytes uint32, data map[Me
 	return result
 }
 
-func (f Formatter) FormatEvent(prefix string, maxPostBytes uint32, event Event) [][]byte {
+func (f Formatter) FormatEvent(prefix string, maxPostBytes uint32, event Event) ([][]byte, error) {
 	var result [][]byte
-	eventsBytes, _ := json.Marshal(event)
-	return append(result, eventsBytes)
+	eventsBytes, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+	return append(result, eventsBytes), err
 }
 
 func formatMetrics(prefix string, data map[MetricKey]MetricValue) []byte {

--- a/datadogclient/formatter.go
+++ b/datadogclient/formatter.go
@@ -4,7 +4,7 @@ import "encoding/json"
 
 type Formatter struct{}
 
-func (f Formatter) Format(prefix string, maxPostBytes uint32, data map[MetricKey]MetricValue) [][]byte {
+func (f Formatter) FormatMetrics(prefix string, maxPostBytes uint32, data map[MetricKey]MetricValue) [][]byte {
 	if len(data) == 0 {
 		return nil
 	}
@@ -13,14 +13,20 @@ func (f Formatter) Format(prefix string, maxPostBytes uint32, data map[MetricKey
 	seriesBytes := formatMetrics(prefix, data)
 	if uint32(len(seriesBytes)) > maxPostBytes && canSplit(data) {
 		metricsA, metricsB := splitPoints(data)
-		result = append(result, f.Format(prefix, maxPostBytes, metricsA)...)
-		result = append(result, f.Format(prefix, maxPostBytes, metricsB)...)
+		result = append(result, f.FormatMetrics(prefix, maxPostBytes, metricsA)...)
+		result = append(result, f.FormatMetrics(prefix, maxPostBytes, metricsB)...)
 
 		return result
 	}
 
 	result = append(result, seriesBytes)
 	return result
+}
+
+func (f Formatter) FormatEvent(prefix string, maxPostBytes uint32, event Event) [][]byte {
+	var result [][]byte
+	eventsBytes, _ := json.Marshal(event)
+	return append(result, eventsBytes)
 }
 
 func formatMetrics(prefix string, data map[MetricKey]MetricValue) []byte {

--- a/datadogclient/formatter_test.go
+++ b/datadogclient/formatter_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Formatter", func() {
 	})
 
 	It("does not return empty data", func() {
-		result := formatter.Format("some-prefix", 1024, nil)
+		result := formatter.FormatMetrics("some-prefix", 1024, nil)
 		Expect(result).To(HaveLen(0))
 	})
 
@@ -28,7 +28,7 @@ var _ = Describe("Formatter", func() {
 				Value: 9,
 			}},
 		}
-		result := formatter.Format("some-prefix", 1, m)
+		result := formatter.FormatMetrics("some-prefix", 1, m)
 
 		Expect(result).To(HaveLen(1))
 	})

--- a/datadogfirehosenozzle/datadog_firehose_nozzle.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle.go
@@ -90,7 +90,7 @@ func (d *DatadogFirehoseNozzle) postToDatadog() error {
 			}
 
 			d.handleMessage(envelope)
-			d.client.AddMetric(envelope)
+			d.client.Add(envelope)
 		case err := <-d.errs:
 			d.handleError(err)
 			return err
@@ -99,7 +99,7 @@ func (d *DatadogFirehoseNozzle) postToDatadog() error {
 }
 
 func (d *DatadogFirehoseNozzle) postMetrics() {
-	err := d.client.PostMetrics()
+	err := d.client.Post()
 	if err != nil {
 		d.log.Fatalf("FATAL ERROR: %s\n\n", err)
 	}


### PR DESCRIPTION
### What does this PR do?

This PR will add support for emitting metron errors events to DataDog.

### Motivation

Our team thought it would be nice to see error events on CI radiators.

### Additional Notes

Related to https://github.com/DataDog/datadog-firehose-nozzle-release/pull/15