### PR TITLE
remove origin from metric name

### DIFF
--- a/datadogclient/datadog_client.go
+++ b/datadogclient/datadog_client.go
@@ -221,9 +221,9 @@ func (c *Client) addInternalMetric(name string, value uint64) {
 func getName(envelope *events.Envelope) string {
 	switch envelope.GetEventType() {
 	case events.Envelope_ValueMetric:
-		return envelope.GetOrigin() + "." + envelope.GetValueMetric().GetName()
+		return envelope.GetValueMetric().GetName()
 	case events.Envelope_CounterEvent:
-		return envelope.GetOrigin() + "." + envelope.GetCounterEvent().GetName()
+		return envelope.GetCounterEvent().GetName()
 	default:
 		panic("Unknown event type")
 	}

--- a/datadogclient/datadog_client_test.go
+++ b/datadogclient/datadog_client_test.go
@@ -137,7 +137,7 @@ var _ = Describe("DatadogClient", func() {
 		Expect(payload.Series).To(HaveLen(4))
 
 		var metric datadogclient.Metric
-		Expect(payload.Series).To(ContainMetric("datadog.nozzle.test-origin.", &metric))
+		Expect(payload.Series).To(ContainMetric("datadog.nozzle.", &metric))
 		Expect(metric.Tags).To(ConsistOf(
 			"deployment:deployment-name",
 			"job:doppler",
@@ -196,7 +196,7 @@ var _ = Describe("DatadogClient", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(payload.Series).To(HaveLen(5))
 		Expect(payload.Series).To(ContainMetricWithTags(
-			"datadog.nozzle.test-origin.",
+			"datadog.nozzle.",
 			"deployment:deployment-name",
 			"index:1",
 			"ip:10.0.1.2",
@@ -207,7 +207,7 @@ var _ = Describe("DatadogClient", func() {
 			"request_id:d3ac-livefood",
 		))
 		Expect(payload.Series).To(ContainMetricWithTags(
-			"datadog.nozzle.test-origin.",
+			"datadog.nozzle.",
 			"deployment:deployment-name",
 			"index:1",
 			"ip:10.0.1.2",
@@ -322,7 +322,7 @@ var _ = Describe("DatadogClient", func() {
 		for _, metric := range payload.Series {
 			Expect(metric.Type).To(Equal("gauge"))
 
-			if metric.Metric == "datadog.nozzle.origin.metricName" {
+			if metric.Metric == "datadog.nozzle.metricName" {
 				metricFound = true
 				Expect(metric.Points).To(Equal([]datadogclient.Point{
 					datadogclient.Point{
@@ -434,7 +434,7 @@ var _ = Describe("DatadogClient", func() {
 		for _, metric := range payload.Series {
 			Expect(metric.Type).To(Equal("gauge"))
 
-			if metric.Metric == "datadog.nozzle.origin.metricName" {
+			if metric.Metric == "datadog.nozzle.metricName" {
 				Expect(metric.Tags).To(HaveLen(4))
 				Expect(metric.Tags[0]).To(Equal("deployment:deployment-name"))
 				if metric.Tags[1] == "job:doppler" {
@@ -499,7 +499,7 @@ var _ = Describe("DatadogClient", func() {
 		for _, metric := range payload.Series {
 			Expect(metric.Type).To(Equal("gauge"))
 
-			if metric.Metric == "datadog.nozzle.origin.counterName" {
+			if metric.Metric == "datadog.nozzle.counterName" {
 				counterNameFound = true
 				Expect(metric.Points).To(Equal([]datadogclient.Point{
 					datadogclient.Point{


### PR DESCRIPTION
The metric name doesn't need to have the origin in it. It's confusing and prevents aggregation across multiple different kinds of hosts. You should be able to aggregate something like cpu or memory usage over any kind of host, not just over one type of host.

This PR removes the origin from the metric name:

`cloudfoundry.redis.cpu` becomes `cloudfoundry.cpu` and in its place it substitutes a tag.