### PR TITLE
Add FlushMaxBytes to default config

### DIFF
--- a/config/datadog-firehose-nozzle.json
+++ b/config/datadog-firehose-nozzle.json
@@ -8,6 +8,7 @@
   "DataDogAPIKey": "<enter api key>",
   "DataDogTimeoutSeconds": 5,
   "FlushDurationSeconds": 15,
+  "FlushMaxBytes": 57671680,
   "InsecureSSLSkipVerify": true,
   "MetricPrefix": "datadogclient",
   "Deployment": "deployment-name",


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

The nozzle panics if  config.FlushMaxBytes isn't set, and although there *is* one provided for the bosh release there isn't one in the default config file we provide here.

Used same default value present in the bosh release: https://github.com/DataDog/datadog-firehose-nozzle-release/blob/master/jobs/datadog-firehose-nozzle/spec#L25

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
