### PR TITLE
Send metric twice, with old & new name

### DIFF
--- a/datadogclient/datadog_client.go
+++ b/datadogclient/datadog_client.go
@@ -127,6 +127,10 @@ func (c *Client) AddMetric(envelope *events.Envelope) {
 	})
 
 	c.metricPoints[key] = mVal
+
+	// Add the metric again with the "old" name (so as not to break any current user's dashboards/monitors)
+	key.Name = envelope.GetOrigin() + "." + key.Name
+	c.metricPoints[key] = mVal
 }
 
 func (c *Client) PostMetrics() error {
@@ -220,10 +224,12 @@ func (c *Client) addInternalMetric(name string, value uint64) {
 
 func getName(envelope *events.Envelope) string {
 	switch envelope.GetEventType() {
+
 	case events.Envelope_ValueMetric:
-		return envelope.GetOrigin() + "." + envelope.GetValueMetric().GetName()
+		return envelope.GetValueMetric().GetName()
+
 	case events.Envelope_CounterEvent:
-		return envelope.GetOrigin() + "." + envelope.GetCounterEvent().GetName()
+		return envelope.GetCounterEvent().GetName()
 	default:
 		panic("Unknown event type")
 	}

--- a/datadogfirehosenozzle/datadog_firehose_nozzle_test.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 		err := json.Unmarshal(contents, &payload)
 		Expect(err).ToNot(HaveOccurred())
 		// +3 internal metrics that show totalMessagesReceived, totalMetricSent, and slowConsumerAlert
-		Expect(payload.Series).To(HaveLen(13))
+		Expect(payload.Series).To(HaveLen(23))
 
 	}, 2)
 

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -112,7 +112,7 @@ var _ = Describe("DatadogFirehoseNozzle", func() {
 		for _, metric := range payload.Series {
 			Expect(metric.Type).To(Equal("gauge"))
 
-			if metric.Metric == "cloudfoundry.nozzle.origin.metricName" {
+			if metric.Metric == "cloudfoundry.nozzle.origin.metricName" || metric.Metric == "cloudfoundry.nozzle.metricName" {
 				Expect(metric.Tags).To(HaveLen(4))
 				Expect(metric.Tags[0]).To(Equal("deployment:deployment-name"))
 				if metric.Tags[1] == "job:doppler" {
@@ -132,7 +132,7 @@ var _ = Describe("DatadogFirehoseNozzle", func() {
 				} else {
 					panic("Unknown tag")
 				}
-			} else if metric.Metric == "cloudfoundry.nozzle.origin.counterName" {
+			} else if metric.Metric == "cloudfoundry.nozzle.origin.counterName" || metric.Metric == "cloudfoundry.nozzle.counterName" {
 				Expect(metric.Tags).To(HaveLen(4))
 				Expect(metric.Tags[0]).To(Equal("deployment:deployment-name"))
 				Expect(metric.Tags[1]).To(Equal("job:doppler"))


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Sends each metric twice, once named properly and once named "the old way" (aka containing the origin of the metric). For example: 
`cloudfoundry.nozzle.analyzer.memoryStats.numBytesAllocated` and `cloudfoundry.nozzle.memoryStats.numBytesAllocated`.

### Motivation

The metric name shouldn't have the origin in it - this does not follow our best practices, and the origin name is already present as a tag. However, we can't outright change all the naming conventions, or we would break current user's dashboards/monitors; so as a compromise, we send the metric in both formats. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
