### PR TITLE
Use channels instead of locks in the nozzle

### DIFF
--- a/datadogfirehosenozzle/datadog_firehose_nozzle.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle.go
@@ -150,7 +150,11 @@ func (d *DatadogFirehoseNozzle) Stop() {
 
 func (d *DatadogFirehoseNozzle) PostMetrics() {
 	d.mapLock.Lock()
-	metricsMap := d.metricsMap
+	// deep copy the metrics map to pass to PostMetrics so that we can unlock d.metricsMap while posting
+	metricsMap := make(metrics.MetricsMap)
+	for k, v := range d.metricsMap {
+		metricsMap[k] = v
+	}
 	totalMessagesReceived := d.totalMessagesReceived
 	d.mapLock.Unlock()
 

--- a/datadogfirehosenozzle/datadog_firehose_nozzle.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle.go
@@ -2,11 +2,14 @@ package datadogfirehosenozzle
 
 import (
 	"crypto/tls"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"code.cloudfoundry.org/localip"
 	"github.com/DataDog/datadog-firehose-nozzle/appmetrics"
 	"github.com/DataDog/datadog-firehose-nozzle/datadogclient"
+	"github.com/DataDog/datadog-firehose-nozzle/metricProcessor"
 	"github.com/DataDog/datadog-firehose-nozzle/metrics"
 	"github.com/DataDog/datadog-firehose-nozzle/nozzleconfig"
 	"github.com/cloudfoundry/gosteno"
@@ -17,18 +20,23 @@ import (
 )
 
 type DatadogFirehoseNozzle struct {
-	config           *nozzleconfig.NozzleConfig
-	errs             <-chan error
-	messages         <-chan *events.Envelope
-	metrics          chan metrics.MetricPackage
-	metricPoints     metrics.MetricsMap
-	authTokenFetcher AuthTokenFetcher
-	consumer         *consumer.Consumer
-	client           *datadogclient.Client
-	log              *gosteno.Logger
-	appMetrics       bool
-	stopper          chan bool
-	workersStopper   chan bool
+	config                *nozzleconfig.NozzleConfig
+	errs                  <-chan error
+	messages              <-chan *events.Envelope
+	authTokenFetcher      AuthTokenFetcher
+	consumer              *consumer.Consumer
+	client                *datadogclient.Client
+	processor             *metricProcessor.Processor
+	processedMetrics      chan []metrics.MetricPackage
+	log                   *gosteno.Logger
+	appMetrics            bool
+	stopper               chan bool
+	workersStopper        chan bool
+	mapLock               sync.RWMutex
+	metricsMap            metrics.MetricsMap // modified by workers & main thread
+	totalMessagesReceived uint64             // modified by workers, read by main thread
+	slowConsumerAlert     uint64             // modified by workers, read by main thread
+	totalMetricsSent      uint64
 }
 
 type AuthTokenFetcher interface {
@@ -39,8 +47,8 @@ func NewDatadogFirehoseNozzle(config *nozzleconfig.NozzleConfig, tokenFetcher Au
 	return &DatadogFirehoseNozzle{
 		config:           config,
 		authTokenFetcher: tokenFetcher,
-		metricPoints:     make(metrics.MetricsMap),
-		metrics:          make(chan metrics.MetricPackage),
+		metricsMap:       make(metrics.MetricsMap),
+		processedMetrics: make(chan []metrics.MetricPackage),
 		log:              log,
 		appMetrics:       config.AppMetrics,
 		stopper:          make(chan bool),
@@ -57,6 +65,7 @@ func (d *DatadogFirehoseNozzle) Start() error {
 
 	d.log.Info("Starting DataDog Firehose Nozzle...")
 	d.client = d.createClient()
+	d.processor = d.createProcessor()
 	d.consumeFirehose(authToken)
 	d.startWorkers()
 	err := d.postToDatadog()
@@ -74,7 +83,6 @@ func (d *DatadogFirehoseNozzle) createClient() *datadogclient.Client {
 	client := datadogclient.New(
 		d.config.DataDogURL,
 		d.config.DataDogAPIKey,
-		d.metrics,
 		d.config.MetricPrefix,
 		d.config.Deployment,
 		ipAddress,
@@ -82,6 +90,12 @@ func (d *DatadogFirehoseNozzle) createClient() *datadogclient.Client {
 		d.config.FlushMaxBytes,
 		d.log,
 	)
+
+	return client
+}
+
+func (d *DatadogFirehoseNozzle) createProcessor() *metricProcessor.Processor {
+	processor := metricProcessor.New(d.processedMetrics)
 
 	if d.appMetrics {
 		appMetrics, err := appmetrics.New(
@@ -97,11 +111,11 @@ func (d *DatadogFirehoseNozzle) createClient() *datadogclient.Client {
 			d.log.Warnf("error setting up appMetrics, continuing without application metrics: %v", err)
 		} else {
 			d.log.Debug("setting up app metrics")
-			client.SetAppMetrics(appMetrics)
+			processor.SetAppMetrics(appMetrics)
 		}
 	}
 
-	return client
+	return processor
 }
 
 func (d *DatadogFirehoseNozzle) consumeFirehose(authToken string) {
@@ -118,45 +132,14 @@ func (d *DatadogFirehoseNozzle) postToDatadog() error {
 	for {
 		select {
 		case <-ticker.C:
-			d.postMetrics()
+			d.PostMetrics()
 		case err := <-d.errs:
 			d.handleError(err)
 			return err
 		case <-d.stopper:
 			return nil
-		case m := <-d.metrics:
-			d.metricPoints.Add(*m.MetricKey, *m.MetricValue)
 		}
 	}
-}
-
-func (d *DatadogFirehoseNozzle) work() {
-	for {
-		select {
-		case envelope := <-d.messages:
-			if !d.keepMessage(envelope) {
-				continue
-			}
-			d.handleMessage(envelope)
-			d.client.ProcessMetric(envelope)
-		case <-d.workersStopper:
-			return
-		}
-	}
-}
-
-func (d *DatadogFirehoseNozzle) startWorkers() {
-	for i := 0; i < d.config.NumWorkers; i++ {
-		go d.work()
-	}
-}
-
-func (d *DatadogFirehoseNozzle) stopWorkers() {
-	go func() {
-		for i := 0; i < d.config.NumWorkers; i++ {
-			d.workersStopper <- true
-		}
-	}()
 }
 
 func (d *DatadogFirehoseNozzle) Stop() {
@@ -165,12 +148,31 @@ func (d *DatadogFirehoseNozzle) Stop() {
 	}()
 }
 
-func (d *DatadogFirehoseNozzle) postMetrics() {
-	err := d.client.PostMetrics(d.metricPoints)
-	d.metricPoints = make(metrics.MetricsMap)
+func (d *DatadogFirehoseNozzle) PostMetrics() {
+	d.mapLock.Lock()
+	metricsMap := d.metricsMap
+	totalMessagesReceived := d.totalMessagesReceived
+	d.mapLock.Unlock()
+
+	// Add internal metrics
+	k, v := d.client.MakeInternalMetric("totalMessagesReceived", totalMessagesReceived)
+	metricsMap[k] = v
+	k, v = d.client.MakeInternalMetric("totalMetricsSent", d.totalMetricsSent)
+	metricsMap[k] = v
+	k, v = d.client.MakeInternalMetric("slowConsumerAlert", atomic.LoadUint64(&d.slowConsumerAlert))
+	metricsMap[k] = v
+
+	err := d.client.PostMetrics(metricsMap)
 	if err != nil {
 		d.log.Errorf("Error posting metrics: %s\n\n", err)
+		return
 	}
+
+	d.totalMetricsSent += uint64(len(metricsMap))
+	d.mapLock.Lock()
+	d.metricsMap = make(metrics.MetricsMap)
+	d.mapLock.Unlock()
+	d.ResetSlowConsumerError()
 }
 
 func (d *DatadogFirehoseNozzle) handleError(err error) {
@@ -186,7 +188,7 @@ func (d *DatadogFirehoseNozzle) handleError(err error) {
 		case websocket.ClosePolicyViolation:
 			d.log.Errorf("Error while reading from the firehose: %v", err)
 			d.log.Errorf("Disconnected because nozzle couldn't keep up. Please try scaling up the nozzle.")
-			d.client.AlertSlowConsumerError()
+			d.AlertSlowConsumerError()
 		default:
 			d.log.Errorf("Error while reading from the firehose: %v", err)
 		}
@@ -197,16 +199,17 @@ func (d *DatadogFirehoseNozzle) handleError(err error) {
 
 	d.log.Infof("Closing connection with traffic controller due to %v", err)
 	d.consumer.Close()
-	d.postMetrics()
+	d.PostMetrics()
 }
 
 func (d *DatadogFirehoseNozzle) keepMessage(envelope *events.Envelope) bool {
 	return d.config.DeploymentFilter == "" || d.config.DeploymentFilter == envelope.GetDeployment()
 }
 
-func (d *DatadogFirehoseNozzle) handleMessage(envelope *events.Envelope) {
-	if envelope.GetEventType() == events.Envelope_CounterEvent && envelope.CounterEvent.GetName() == "TruncatingBuffer.DroppedMessages" && envelope.GetOrigin() == "doppler" {
-		d.log.Infof("We've intercepted an upstream message which indicates that the nozzle or the TrafficController is not keeping up. Please try scaling up the nozzle.")
-		d.client.AlertSlowConsumerError()
-	}
+func (d *DatadogFirehoseNozzle) ResetSlowConsumerError() {
+	atomic.StoreUint64(&d.slowConsumerAlert, 0)
+}
+
+func (d *DatadogFirehoseNozzle) AlertSlowConsumerError() {
+	atomic.StoreUint64(&d.slowConsumerAlert, 1)
 }

--- a/datadogfirehosenozzle/datadog_firehose_nozzle.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle.go
@@ -20,7 +20,7 @@ type DatadogFirehoseNozzle struct {
 	config           *nozzleconfig.NozzleConfig
 	errs             <-chan error
 	messages         <-chan *events.Envelope
-	metrics          <-chan metrics.MetricPackage
+	metrics          chan metrics.MetricPackage
 	metricPoints     metrics.MetricsMap
 	authTokenFetcher AuthTokenFetcher
 	consumer         *consumer.Consumer

--- a/datadogfirehosenozzle/workers.go
+++ b/datadogfirehosenozzle/workers.go
@@ -1,0 +1,62 @@
+package datadogfirehosenozzle
+
+import (
+	"github.com/cloudfoundry/sonde-go/events"
+)
+
+func (d *DatadogFirehoseNozzle) startWorkers() {
+	// Start the (multiple) workers which will process envelopes
+	for i := 0; i < d.config.NumWorkers; i++ {
+		go d.work()
+	}
+
+	// Start the (one) worker which will store metrics as they're generated
+	go d.readProcessedMetrics()
+}
+
+func (d *DatadogFirehoseNozzle) stopWorkers() {
+	go func() {
+		for i := 0; i < d.config.NumWorkers+1; i++ {
+			// +1 is for the readProcessedMetrics worker
+			d.workersStopper <- true
+		}
+	}()
+}
+
+func (d *DatadogFirehoseNozzle) work() {
+	for {
+		select {
+		case envelope := <-d.messages:
+			if !d.keepMessage(envelope) {
+				continue
+			}
+			d.handleMessage(envelope)
+			d.processor.ProcessMetric(envelope)
+		case <-d.workersStopper:
+			return
+		}
+	}
+}
+
+func (d *DatadogFirehoseNozzle) readProcessedMetrics() {
+	for {
+		select {
+		case pkg := <-d.processedMetrics:
+			d.mapLock.Lock()
+			d.totalMessagesReceived++
+			for _, m := range pkg {
+				d.metricsMap.Add(*m.MetricKey, *m.MetricValue)
+			}
+			d.mapLock.Unlock()
+		case <-d.workersStopper:
+			return
+		}
+	}
+}
+
+func (d *DatadogFirehoseNozzle) handleMessage(envelope *events.Envelope) {
+	if envelope.GetEventType() == events.Envelope_CounterEvent && envelope.CounterEvent.GetName() == "TruncatingBuffer.DroppedMessages" && envelope.GetOrigin() == "doppler" {
+		d.log.Infof("We've intercepted an upstream message which indicates that the nozzle or the TrafficController is not keeping up. Please try scaling up the nozzle.")
+		d.AlertSlowConsumerError()
+	}
+}

--- a/metricProcessor/appmetrics.go
+++ b/metricProcessor/appmetrics.go
@@ -1,4 +1,4 @@
-package datadogclient
+package metricProcessor
 
 import (
 	"fmt"
@@ -7,11 +7,11 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
-func (c *Client) ParseAppMetric(envelope *events.Envelope) ([]metrics.MetricPackage, error) {
+func (p *Processor) ParseAppMetric(envelope *events.Envelope) ([]metrics.MetricPackage, error) {
 	metricsPackages := []metrics.MetricPackage{}
 	var err error
 
-	if c.appMetrics == nil {
+	if p.appMetrics == nil {
 		return metricsPackages, fmt.Errorf("app metrics are not configured")
 	}
 
@@ -19,7 +19,7 @@ func (c *Client) ParseAppMetric(envelope *events.Envelope) ([]metrics.MetricPack
 		return metricsPackages, fmt.Errorf("not an app metric")
 	}
 
-	metricsPackages, err = c.appMetrics.ParseAppMetric(envelope)
+	metricsPackages, err = p.appMetrics.ParseAppMetric(envelope)
 
 	return metricsPackages, err
 }

--- a/metricProcessor/inframetrics.go
+++ b/metricProcessor/inframetrics.go
@@ -1,4 +1,4 @@
-package datadogclient
+package metricProcessor
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
-func (c *Client) ParseInfraMetric(envelope *events.Envelope) ([]metrics.MetricPackage, error) {
+func (p *Processor) ParseInfraMetric(envelope *events.Envelope) ([]metrics.MetricPackage, error) {
 	metricsPackages := []metrics.MetricPackage{}
 
 	if envelope.GetEventType() != events.Envelope_ValueMetric && envelope.GetEventType() != events.Envelope_CounterEvent {

--- a/metricProcessor/metricProcessor.go
+++ b/metricProcessor/metricProcessor.go
@@ -1,0 +1,37 @@
+package metricProcessor
+
+import (
+	"github.com/DataDog/datadog-firehose-nozzle/appmetrics"
+	"github.com/DataDog/datadog-firehose-nozzle/metrics"
+	"github.com/cloudfoundry/sonde-go/events"
+)
+
+type Processor struct {
+	processedMetrics chan<- []metrics.MetricPackage
+	appMetrics       *appmetrics.AppMetrics
+}
+
+func New(pm chan<- []metrics.MetricPackage) *Processor {
+	return &Processor{processedMetrics: pm}
+}
+
+func (p *Processor) SetAppMetrics(appMetrics *appmetrics.AppMetrics) {
+	p.appMetrics = appMetrics
+}
+
+func (p *Processor) ProcessMetric(envelope *events.Envelope) {
+	var err error
+	var metricsPackages []metrics.MetricPackage
+
+	metricsPackages, err = p.ParseInfraMetric(envelope)
+	if err == nil {
+		p.processedMetrics <- metricsPackages
+		// it can only be one or the other
+		return
+	}
+
+	metricsPackages, err = p.ParseAppMetric(envelope)
+	if err == nil {
+		p.processedMetrics <- metricsPackages
+	}
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -29,11 +29,6 @@ type MetricPackage struct {
 	MetricValue *MetricValue
 }
 
-type Metric struct {
-	MetricKey   *MetricKey
-	MetricValue *MetricValue
-}
-
 type MetricsMap map[MetricKey]MetricValue
 
 func (m MetricsMap) Add(key MetricKey, newVal MetricValue) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -29,6 +29,23 @@ type MetricPackage struct {
 	MetricValue *MetricValue
 }
 
+type Metric struct {
+	MetricKey   *MetricKey
+	MetricValue *MetricValue
+}
+
+type MetricsMap map[MetricKey]MetricValue
+
+func (m MetricsMap) Add(key MetricKey, newVal MetricValue) {
+	value, exists := m[key]
+	if exists {
+		value.Points = append(value.Points, newVal.Points...)
+	} else {
+		value = newVal
+	}
+	m[key] = value
+}
+
 type Series struct {
 	Metric string   `json:"metric"`
 	Points []Point  `json:"points"`


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Changes the way the nozzle handles the metrics it receives:
- The nozzle owns a `Client`, which handles posting metrics to Datadog, and a `Processor`, which parses envelopes into infra/app metrics and then passes them into the `processedMetrics` channel (also owned by the nozzle)
- The nozzle has 2 types of workers:
    1) workers who listen for envelopes on the `messages` channel and then hand them off to the `Processor` to process
    2) 1 worker who listen for processed metrics on the `processedMetrics` channel and adds them to the nozzle's `metricsMap` when they arrive
- When it's time to post metrics (according to the configured flush duration), the nozzle's main thread makes a copy of the `metricsMap`, adds internal metrics, then handles this map off to the `Client` to send to Datadog

Previously, the `Client` was responsible for processing metrics, adding them to its `metricPoints` map, and then posting them when the time came. As a result, there were multiple threads that could potentially be stuck waiting to acquire a lock on the map:
- when envelopes arrived workers would lock the map to add metrics to it
- when it was time for the main thread to post metrics it would lock the map, empty it, and then send all those metrics

### Motivation

https://github.com/DataDog/datadog-firehose-nozzle/pull/13 made the nozzle multithreaded with a worker paradigm. However, it still stores all the series in a map, which is protected by a lock. This data structure works, but is not optimal and makes adding in a bunch of different kinds of optimizations and redundancies harder.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

The changes to the tests were pulled into a separate PR that should be merged after this one: https://github.com/DataDog/datadog-firehose-nozzle/pull/23
