### PR TITLE
Ensure app exists before performaing any actions on it

### DIFF
--- a/appmetrics/app_metrics.go
+++ b/appmetrics/app_metrics.go
@@ -217,13 +217,13 @@ func (am *AppMetrics) ParseAppMetric(envelope *events.Envelope) ([]metrics.Metri
 
 	guid := message.GetApplicationId()
 	app, err := am.getAppData(guid)
-	app.lock.Lock()
-	defer app.lock.Unlock()
-
-	if err != nil {
+	if err != nil || app == nil {
 		am.log.Errorf("there was an error grabbing data for app %v: %v", guid, err)
 		return metricsPackages, err
 	}
+
+	app.lock.Lock()
+	defer app.lock.Unlock()
 
 	app.Host = envelope.GetOrigin()
 


### PR DESCRIPTION
### What does this PR do?

If an app doesn't exist and we try to lock it, we'll get an NPE. We should ensure it exists and ensure there are no errors, then attempt to lock it