### PR TITLE
Minor cleanup in the `nozzleconfig` package

### DIFF
--- a/nozzleconfig/nozzle_config.go
+++ b/nozzleconfig/nozzle_config.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 )
 
-var (
-	DefaultWorkers int = 4
+const (
+	defaultWorkers int = 4
 )
 
 type NozzleConfig struct {
@@ -71,7 +71,7 @@ func Parse(configPath string) (*NozzleConfig, error) {
 	}
 
 	if config.NumWorkers == 0 {
-		config.NumWorkers = DefaultWorkers
+		config.NumWorkers = defaultWorkers
 	}
 
 	overrideWithEnvInt("NOZZLE_NUM_WORKERS", &config.NumWorkers)

--- a/nozzleconfig/nozzle_config.go
+++ b/nozzleconfig/nozzle_config.go
@@ -17,7 +17,6 @@ type NozzleConfig struct {
 	Client                  string
 	ClientSecret            string
 	TrafficControllerURL    string
-	DopplerEndpoint         string
 	FirehoseSubscriptionID  string
 	DataDogURL              string
 	DataDogAPIKey           string


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Minor cleanup in the `nozzleconfig` package.
- `DopplerEndpoint` is synonymous to `TrafficControllerURL` but it isn't used anywhere in the code.
- `DefaultWorkers` need not be exported and can be fixed. I don't see the need to update the number of "DefaultWorkers", that's what the config property `NumWorkers` is for.

### Motivation

What inspired you to submit this pull request?
Contributing to open source and making the world a better place.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
Nope.