### PR TITLE
Add configurable global tags

### DIFF
--- a/appmetrics/app.go
+++ b/appmetrics/app.go
@@ -50,7 +50,7 @@ func newApp(guid string) *App {
 	}
 }
 
-func (a *App) getMetrics() []metrics.MetricPackage {
+func (a *App) getMetrics(customTags []string) []metrics.MetricPackage {
 	var names = []string{
 		"app.disk.configured",
 		"app.disk.provisioned",
@@ -67,7 +67,7 @@ func (a *App) getMetrics() []metrics.MetricPackage {
 		float64(a.NumberOfInstances),
 	}
 
-	return a.mkMetrics(names, ms, []string{})
+	return a.mkMetrics(names, ms, customTags)
 }
 
 func (a *App) mkMetrics(names []string, ms []float64, moreTags []string) []metrics.MetricPackage {
@@ -104,7 +104,7 @@ func (a *App) mkMetrics(names []string, ms []float64, moreTags []string) []metri
 	return metricsPackages
 }
 
-func (a *App) parseContainerMetric(message *events.ContainerMetric) ([]metrics.MetricPackage, error) {
+func (a *App) parseContainerMetric(message *events.ContainerMetric, customTags []string) ([]metrics.MetricPackage, error) {
 	var names = []string{
 		"app.cpu.pct",
 		"app.disk.used",
@@ -120,6 +120,7 @@ func (a *App) parseContainerMetric(message *events.ContainerMetric) ([]metrics.M
 		float64(message.GetMemoryBytesQuota()),
 	}
 	tags := []string{fmt.Sprintf("instance:%v", message.GetInstanceIndex())}
+	tags = append(tags, customTags...)
 
 	return a.mkMetrics(names, ms, tags), nil
 }

--- a/appmetrics/app_metrics.go
+++ b/appmetrics/app_metrics.go
@@ -211,7 +211,7 @@ func (am *AppMetrics) getAppData(guid string) (*App, error) {
 	return app, nil
 }
 
-func (am *AppMetrics) ParseAppMetric(envelope *events.Envelope) ([]metrics.MetricPackage, error) {
+func (am *AppMetrics) ParseAppMetric(envelope *events.Envelope, customTags []string) ([]metrics.MetricPackage, error) {
 	metricsPackages := []metrics.MetricPackage{}
 	message := envelope.GetContainerMetric()
 
@@ -227,8 +227,8 @@ func (am *AppMetrics) ParseAppMetric(envelope *events.Envelope) ([]metrics.Metri
 
 	app.Host = envelope.GetOrigin()
 
-	metricsPackages = app.getMetrics()
-	containerMetrics, err := app.parseContainerMetric(message)
+	metricsPackages = app.getMetrics(customTags)
+	containerMetrics, err := app.parseContainerMetric(message, customTags)
 	if err != nil {
 		return metricsPackages, err
 	}

--- a/appmetrics/app_metrics_test.go
+++ b/appmetrics/app_metrics_test.go
@@ -1,12 +1,16 @@
 package appmetrics
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-firehose-nozzle/metrics"
 	. "github.com/DataDog/datadog-firehose-nozzle/testhelpers"
 	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/sonde-go/events"
@@ -26,14 +30,14 @@ var _ = Describe("AppMetrics", func() {
 		ccAPIURL = fakeCloudControllerAPI.URL()
 	}, 0)
 
-	Context("genertor function", func() {
+	Context("generator function", func() {
 		It("errors out properly when it cannot connect", func() {
-			_, err := New("http://localhost", "", "", true, 10, log)
+			_, err := New("http://localhost", "", "", true, 10, log, []string{})
 			Expect(err).NotTo(BeNil())
 		})
 
 		It("generates it properly when it can connect", func() {
-			a, err := New(ccAPIURL, "bearer", "123456789", true, 10, log)
+			a, err := New(ccAPIURL, "bearer", "123456789", true, 10, log, []string{})
 			Expect(err).To(BeNil())
 			Expect(a).NotTo(BeNil())
 		})
@@ -41,13 +45,13 @@ var _ = Describe("AppMetrics", func() {
 
 	Context("app metrics test", func() {
 		It("tries to get it from the cloud controller when the cache is empty", func() {
-			a, _ := New(ccAPIURL, "bearer", "123456789", true, 10, log)
+			a, _ := New(ccAPIURL, "bearer", "123456789", true, 10, log, []string{})
 			_, err := a.getAppData("guid")
 			Expect(err).NotTo(BeNil())
 		})
 
 		It("grabs from the cache when it should be", func() {
-			a, _ := New(ccAPIURL, "bearer", "123456789", true, 10, log)
+			a, _ := New(ccAPIURL, "bearer", "123456789", true, 10, log, []string{})
 			guids := []string{"guid1", "guid2"}
 			a.Apps = newFakeApps(guids)
 			app, err := a.getAppData("guid1")
@@ -58,7 +62,7 @@ var _ = Describe("AppMetrics", func() {
 
 	Context("metric evaluation test", func() {
 		It("parses an event properly", func() {
-			a, err := New(ccAPIURL, "bearer", "123456789", true, 10, log)
+			a, err := New(ccAPIURL, "bearer", "123456789", true, 10, log, []string{})
 			Expect(err).To(BeNil())
 			guids := []string{"guid1", "guid2"}
 			a.Apps = newFakeApps(guids)
@@ -84,17 +88,32 @@ var _ = Describe("AppMetrics", func() {
 				Ip:         proto.String("10.0.1.2"),
 			}
 
-			metrics, err := a.ParseAppMetric(event, []string{})
+			metrics, err := a.ParseAppMetric(event)
 
 			Expect(err).To(BeNil())
 			Expect(metrics).To(HaveLen(10))
-			Expect(metrics[0].MetricValue.Tags).To(HaveLen(2))
+
+			Expect(metrics).To(ContainMetric("app.disk.configured"))
+			Expect(metrics).To(ContainMetric("app.disk.provisioned"))
+			Expect(metrics).To(ContainMetric("app.memory.configured"))
+			Expect(metrics).To(ContainMetric("app.memory.provisioned"))
+			Expect(metrics).To(ContainMetric("app.instances"))
+			Expect(metrics).To(ContainMetric("app.cpu.pct"))
+			Expect(metrics).To(ContainMetric("app.disk.used"))
+			Expect(metrics).To(ContainMetric("app.disk.quota"))
+			Expect(metrics).To(ContainMetric("app.memory.used"))
+			Expect(metrics).To(ContainMetric("app.memory.quota"))
+
+			for _, metric := range metrics {
+				Expect(metric.MetricValue.Tags).To(ContainElement("app_name:guid1"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("guid:guid1"))
+			}
 		})
 	})
 
 	Context("custom tags", func() {
-		It("sends attaches custom tags if present", func() {
-			a, err := New(ccAPIURL, "bearer", "123456789", true, 10, log)
+		It("attaches custom tags if present", func() {
+			a, err := New(ccAPIURL, "bearer", "123456789", true, 10, log, []string{"custom:tag", "foo:bar"})
 			Expect(err).To(BeNil())
 			guids := []string{"guid1", "guid2"}
 			a.Apps = newFakeApps(guids)
@@ -120,7 +139,7 @@ var _ = Describe("AppMetrics", func() {
 				Ip:         proto.String("10.0.1.2"),
 			}
 
-			metrics, err := a.ParseAppMetric(event, []string{"custom:tag", "foo:bar"})
+			metrics, err := a.ParseAppMetric(event)
 
 			Expect(err).To(BeNil())
 			Expect(metrics).To(HaveLen(10))
@@ -135,6 +154,39 @@ var _ = Describe("AppMetrics", func() {
 	})
 
 })
+
+type containMetric struct {
+	needle   string
+	haystack []metrics.MetricPackage
+}
+
+func ContainMetric(name string) types.GomegaMatcher {
+	return &containMetric{
+		needle: name,
+	}
+}
+
+func (m *containMetric) Match(actual interface{}) (success bool, err error) {
+	var ok bool
+	m.haystack, ok = actual.([]metrics.MetricPackage)
+	if !ok {
+		return false, errors.New("Actual must be of type []metrics.MetricPackage")
+	}
+	for _, pkg := range m.haystack {
+		if pkg.MetricKey.Name == m.needle {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *containMetric) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected %#v to contain a metric named %s", m.haystack, m.needle)
+}
+
+func (m *containMetric) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Did not expect %#v to contain a metric named %s", m.haystack, m.needle)
+}
 
 func newFakeApps(guids []string) map[string]*App {
 	apps := map[string]*App{}

--- a/datadogclient/appmetrics.go
+++ b/datadogclient/appmetrics.go
@@ -19,7 +19,7 @@ func (c *Client) ParseAppMetric(envelope *events.Envelope) ([]metrics.MetricPack
 		return metricsPackages, fmt.Errorf("not an app metric")
 	}
 
-	metricsPackages, err = c.appMetrics.ParseAppMetric(envelope)
+	metricsPackages, err = c.appMetrics.ParseAppMetric(envelope, c.customTags)
 
 	return metricsPackages, err
 }

--- a/datadogclient/appmetrics.go
+++ b/datadogclient/appmetrics.go
@@ -19,7 +19,7 @@ func (c *Client) ParseAppMetric(envelope *events.Envelope) ([]metrics.MetricPack
 		return metricsPackages, fmt.Errorf("not an app metric")
 	}
 
-	metricsPackages, err = c.appMetrics.ParseAppMetric(envelope, c.customTags)
+	metricsPackages, err = c.appMetrics.ParseAppMetric(envelope)
 
 	return metricsPackages, err
 }

--- a/datadogclient/inframetrics.go
+++ b/datadogclient/inframetrics.go
@@ -16,8 +16,9 @@ func (c *Client) ParseInfraMetric(envelope *events.Envelope) ([]metrics.MetricPa
 		return metricsPackages, fmt.Errorf("not an infra metric")
 	}
 
-	tags := parseTags(envelope)
 	host := parseHost(envelope)
+	tags := parseTags(envelope)
+	tags = append(tags, c.customTags...)
 
 	key := metrics.MetricKey{
 		EventType: envelope.GetEventType(),

--- a/datadogfirehosenozzle/datadog_firehose_nozzle.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle.go
@@ -51,7 +51,7 @@ func (d *DatadogFirehoseNozzle) Start() error {
 	}
 
 	d.log.Info("Starting DataDog Firehose Nozzle...")
-	d.client = d.createClient()
+	d.client = d.createClient(d.config.CustomTags)
 	d.consumeFirehose(authToken)
 	d.startWorkers()
 	err := d.postToDatadog()
@@ -60,10 +60,14 @@ func (d *DatadogFirehoseNozzle) Start() error {
 	return err
 }
 
-func (d *DatadogFirehoseNozzle) createClient() *datadogclient.Client {
+func (d *DatadogFirehoseNozzle) createClient(customTags []string) *datadogclient.Client {
 	ipAddress, err := localip.LocalIP()
 	if err != nil {
 		panic(err)
+	}
+
+	if d.config.CustomTags == nil {
+		d.config.CustomTags = []string{}
 	}
 
 	client := datadogclient.New(
@@ -75,6 +79,7 @@ func (d *DatadogFirehoseNozzle) createClient() *datadogclient.Client {
 		time.Duration(d.config.DataDogTimeoutSeconds)*time.Second,
 		d.config.FlushMaxBytes,
 		d.log,
+		d.config.CustomTags,
 	)
 
 	if d.appMetrics {

--- a/datadogfirehosenozzle/datadog_firehose_nozzle.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle.go
@@ -90,6 +90,7 @@ func (d *DatadogFirehoseNozzle) createClient(customTags []string) *datadogclient
 			d.config.InsecureSSLSkipVerify,
 			d.config.GrabInterval,
 			d.log,
+			d.config.CustomTags,
 		)
 		if err != nil {
 			d.appMetrics = false

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -147,15 +147,15 @@ var _ = Describe("DatadogFirehoseNozzle", func() {
 				}))
 			} else if metric.Metric == "cloudfoundry.nozzle.totalMessagesReceived" {
 				Expect(metric.Tags).To(HaveLen(2))
-				Expect(metric.Tags[0]).To(HavePrefix("ip:"))
-				Expect(metric.Tags[1]).To(HavePrefix("deployment:"))
+				Expect(metric.Tags[0]).To(HavePrefix("deployment:"))
+				Expect(metric.Tags[1]).To(HavePrefix("ip:"))
 
 				Expect(metric.Points).To(HaveLen(1))
 				Expect(metric.Points[0].Value).To(Equal(3.0))
 			} else if metric.Metric == "cloudfoundry.nozzle.totalMetricsSent" {
 				Expect(metric.Tags).To(HaveLen(2))
-				Expect(metric.Tags[0]).To(HavePrefix("ip:"))
-				Expect(metric.Tags[1]).To(HavePrefix("deployment:"))
+				Expect(metric.Tags[0]).To(HavePrefix("deployment:"))
+				Expect(metric.Tags[1]).To(HavePrefix("ip:"))
 
 				Expect(metric.Points).To(HaveLen(1))
 				Expect(metric.Points[0].Value).To(Equal(0.0))

--- a/nozzleconfig/nozzle_config.go
+++ b/nozzleconfig/nozzle_config.go
@@ -34,6 +34,7 @@ type NozzleConfig struct {
 	AppMetrics              bool
 	NumWorkers              int
 	GrabInterval            int
+	CustomTags              []string
 }
 
 func Parse(configPath string) (*NozzleConfig, error) {

--- a/nozzleconfig/nozzle_config_test.go
+++ b/nozzleconfig/nozzle_config_test.go
@@ -14,7 +14,7 @@ var _ = Describe("NozzleConfig", func() {
 	})
 
 	It("successfully parses a valid config", func() {
-		conf, err := nozzleconfig.Parse("../config/datadog-firehose-nozzle.json")
+		conf, err := nozzleconfig.Parse("test_config.json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(conf.UAAURL).To(Equal("https://uaa.walnut.cf-app.com"))
 		Expect(conf.Client).To(Equal("user"))
@@ -23,12 +23,18 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.DataDogAPIKey).To(Equal("<enter api key>"))
 		Expect(conf.DataDogTimeoutSeconds).To(BeEquivalentTo(5))
 		Expect(conf.FlushDurationSeconds).To(BeEquivalentTo(15))
+		Expect(conf.FlushMaxBytes).To(BeEquivalentTo(57671680))
 		Expect(conf.InsecureSSLSkipVerify).To(Equal(true))
 		Expect(conf.MetricPrefix).To(Equal("datadogclient"))
 		Expect(conf.Deployment).To(Equal("deployment-name"))
 		Expect(conf.DeploymentFilter).To(Equal("deployment-filter"))
 		Expect(conf.DisableAccessControl).To(Equal(false))
 		Expect(conf.IdleTimeoutSeconds).To(BeEquivalentTo(60))
+		Expect(conf.CustomTags).To(BeEquivalentTo([]string{
+			"nozzle:foobar",
+			"env:prod",
+			"role:db",
+		}))
 	})
 
 	It("successfully overwrites file config values with environmental variables", func() {
@@ -39,6 +45,7 @@ var _ = Describe("NozzleConfig", func() {
 		os.Setenv("NOZZLE_DATADOGAPIKEY", "envapi-key>")
 		os.Setenv("NOZZLE_DATADOGTIMEOUTSECONDS", "10")
 		os.Setenv("NOZZLE_FLUSHDURATIONSECONDS", "25")
+		os.Setenv("NOZZLE_FLUSHMAXBYTES", "12345678")
 		os.Setenv("NOZZLE_INSECURESSLSKIPVERIFY", "false")
 		os.Setenv("NOZZLE_METRICPREFIX", "env-datadogclient")
 		os.Setenv("NOZZLE_DEPLOYMENT", "env-deployment-name")
@@ -46,7 +53,7 @@ var _ = Describe("NozzleConfig", func() {
 		os.Setenv("NOZZLE_DISABLEACCESSCONTROL", "true")
 		os.Setenv("NOZZLE_IDLETIMEOUTSECONDS", "30")
 
-		conf, err := nozzleconfig.Parse("../config/datadog-firehose-nozzle.json")
+		conf, err := nozzleconfig.Parse("test_config.json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(conf.UAAURL).To(Equal("https://uaa.walnut-env.cf-app.com"))
 		Expect(conf.Client).To(Equal("env-user"))
@@ -55,6 +62,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.DataDogAPIKey).To(Equal("envapi-key>"))
 		Expect(conf.DataDogTimeoutSeconds).To(BeEquivalentTo(10))
 		Expect(conf.FlushDurationSeconds).To(BeEquivalentTo(25))
+		Expect(conf.FlushMaxBytes).To(BeEquivalentTo(12345678))
 		Expect(conf.InsecureSSLSkipVerify).To(Equal(false))
 		Expect(conf.MetricPrefix).To(Equal("env-datadogclient"))
 		Expect(conf.Deployment).To(Equal("env-deployment-name"))

--- a/nozzleconfig/test_config.json
+++ b/nozzleconfig/test_config.json
@@ -18,5 +18,5 @@
   "CloudControllerEndpoint": "string",
   "AppMetrics": true,
   "NumWorkers": 1,
-  "CustomTags": []
+  "CustomTags": [ "nozzle:foobar", "env:prod", "role:db" ]
 }


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Adds the ability to set custom tags in the nozzle configuration file which will be attached to all metrics coming from this nozzle (infrastructure metrics, app metrics, internal metrics). 

### Motivation

This allows people to add a tag to metrics coming from the nozzle in a particular environment, thus allowing people to split up their metrics by foundry.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
