### PR TITLE
Modified logging hook attached to HTTP retry client

### DIFF
--- a/datadogclient/datadog_client_test.go
+++ b/datadogclient/datadog_client_test.go
@@ -103,6 +103,9 @@ var _ = Describe("DatadogClient", func() {
 				errs <- c.PostMetrics(metricsMap)
 			}()
 			Eventually(errs).Should(Receive(HaveOccurred()))
+
+			logOutput := fakeBuffer.GetContent()
+			Expect(logOutput).To(ContainSubstring("request canceled (Client.Timeout exceeded while awaiting headers)"))
 		})
 
 		It("attempts to retry the connection", func() {
@@ -120,9 +123,9 @@ var _ = Describe("DatadogClient", func() {
 			Expect(err.Error()).To(ContainSubstring("giving up after 4 attempts"))
 
 			logOutput := fakeBuffer.GetContent()
-			Expect(logOutput).To(ContainSubstring("request failed. Wait before retrying:"))
-			Expect(logOutput).To(ContainSubstring("(2 left)"))
-			Expect(logOutput).To(ContainSubstring("(1 left)"))
+			Expect(logOutput).To(ContainSubstring("retrying in 14.285714ms (3 left)"))
+			Expect(logOutput).To(ContainSubstring("retrying in 28.571428ms (2 left)"))
+			Expect(logOutput).To(ContainSubstring("retrying in 50ms (1 left)"))
 		})
 	})
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Changes the logging hook to properly redirect all the messages coming from the http retry client to our own logger.

### Motivation

The error messages were getting lost, and knowing that we have to retry the request but not knowing why isn't particularly helpful.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
