### PR TITLE
Allow Nozzle URL to be set dynamically

### DIFF
--- a/appmetrics/app_metrics.go
+++ b/appmetrics/app_metrics.go
@@ -23,29 +23,14 @@ type AppMetrics struct {
 }
 
 func New(
-	ccEndpoint string,
-	client string,
-	clientSecret string,
-	insecureSSLSkipVerify bool,
+	cfClient *cfclient.Client,
 	grabInterval int,
 	log *gosteno.Logger,
 	customTags []string,
 ) (*AppMetrics, error) {
 
-	if ccEndpoint == "" {
-		return nil, fmt.Errorf("The CC Endpoint needs to be set in order to set up appmetrics")
-	}
-
-	cfg := cfclient.Config{
-		ApiAddress:        ccEndpoint,
-		ClientID:          client,
-		ClientSecret:      clientSecret,
-		SkipSslValidation: insecureSSLSkipVerify,
-		UserAgent:         "datadog-firehose-nozzle",
-	}
-	cfClient, err := cfclient.NewClient(&cfg)
-	if err != nil {
-		return nil, err
+	if cfClient == nil {
+		return nil, fmt.Errorf("The CF Client needs to be properly set up to use appmetrics")
 	}
 
 	appMetrics := &AppMetrics{


### PR DESCRIPTION
### What does this PR do?

The Nozzle requires setting the loggregator url manually. However, this can cause issues in a PCF tile. A PCF tile does not necessarily have access to the url and (importantly) the port of the loggregator url. What this PR does is allow the loggregator url to be set via the CF client, so only the CF client config is required for this to work. 

The Nozzle preserves the prior functionality, at least for a few cycles.

### Motivation

It's a bug that tiles sometimes fail to work correctly.

### Additional Notes

This is a small change, it should work fine.
