### PR TITLE
Use app.DetectedBuildpack if app.Buildpack is nil

### DIFF
--- a/appmetrics/app_metrics.go
+++ b/appmetrics/app_metrics.go
@@ -183,6 +183,8 @@ func (am *AppMetrics) getAppData(guid string) (*App, error) {
 	}
 	if resolvedApp.Buildpack != "" {
 		app.Buildpack = resolvedApp.Buildpack
+	} else if resolvedApp.DetectedBuildpack != "" {
+		app.Buildpack = resolvedApp.DetectedBuildpack
 	} else if app.Buildpack == "" {
 		app.GrabAgain = true
 	}


### PR DESCRIPTION

### What does this PR do?

If an application buildpack is not specified in the application
manifest, CFClient.Client.AppByGuid will return nil for the
buildpack name.

This can be resolved by using the "detected buildpack" which should
 have a value.


### Motivation

Investigation into why buildpack value was not populated in Datadog

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes


This behavior is equivelent to the `cf cli` application:

https://github.com/cloudfoundry/cli/blob/master/cf/commands/application/app.go#L175