### PR TITLE
Reset the metric map while it is locked

### DIFF
--- a/datadogfirehosenozzle/datadog_firehose_nozzle.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle.go
@@ -269,6 +269,8 @@ func (d *DatadogFirehoseNozzle) PostMetrics() {
 		metricsMap[k] = v
 	}
 	totalMessagesReceived := d.totalMessagesReceived
+	// Reset the map
+	d.metricsMap = make(metrics.MetricsMap)
 	d.mapLock.Unlock()
 
 	timestamp := time.Now().Unix()
@@ -288,9 +290,6 @@ func (d *DatadogFirehoseNozzle) PostMetrics() {
 	}
 
 	d.totalMetricsSent += uint64(len(metricsMap))
-	d.mapLock.Lock()
-	d.metricsMap = make(metrics.MetricsMap)
-	d.mapLock.Unlock()
 	d.ResetSlowConsumerError()
 }
 

--- a/datadogfirehosenozzle/datadog_firehose_nozzle_test.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle_test.go
@@ -151,6 +151,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 		validateMetrics(payload, 10, 0)
 
 		nozzle.Stop()
+		time.Sleep(time.Second)
 		// post again, without having received any new messages
 		nozzle.PostMetrics()
 

--- a/datadogfirehosenozzle/datadog_firehose_nozzle_test.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle_test.go
@@ -150,6 +150,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 
 		validateMetrics(payload, 10, 0)
 
+		nozzle.Stop()
 		// post again, without having received any new messages
 		nozzle.PostMetrics()
 


### PR DESCRIPTION

### What does this PR do?

Move the reset of the metrics map right after we made a copy of it.

### Motivation

Noticed while going through the code. The previous implementation could result in some lost metrics, since the map would be reset after we processed it, while workers could already have modified it since it was unlocked. Those additions would then never be processed

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?