### PR TITLE
Fix app caching logic

### DIFF
--- a/appmetrics/app.go
+++ b/appmetrics/app.go
@@ -31,7 +31,6 @@ type App struct {
 	TotalDiskProvisioned   int
 	TotalMemoryProvisioned int
 	ErrorGrabbing          bool
-	GrabAgain              bool
 	Tags                   []string
 	updated                int64
 	lock                   sync.RWMutex


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fix the caching logic of the apps. There was a bug in the logic where we would always fetch app data from CF, instead of looking up in the cache. This was because the code would request data from cloud foundry if some attributes were missing at the first request. Since those attributes are optional though, this means that there was a big chance some of them would not be set, and we would always fetch from CF.

### Motivation

This bug causes the nozzle to not be able to keep up with the amount of metrics coming in when appMetrics are enabled, because it spends most of its time fetching data from CF.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?