### PR TITLE
Compress metric payloads using zlib

### DIFF
--- a/datadogclient/datadog_client.go
+++ b/datadogclient/datadog_client.go
@@ -128,6 +128,7 @@ func (c *Client) postMetrics(seriesBytes []byte) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "deflate") // Additional header for zlib compression
 
 	// If an error is returned by the client (connection errors, etc.), or if a 500-range
 	// response code is received, then a retry is invoked on this request after a wait period

--- a/datadogclient/formatter_test.go
+++ b/datadogclient/formatter_test.go
@@ -3,6 +3,7 @@ package datadogclient_test
 import (
 	"github.com/DataDog/datadog-firehose-nozzle/datadogclient"
 	"github.com/DataDog/datadog-firehose-nozzle/metrics"
+	"github.com/DataDog/datadog-firehose-nozzle/testhelpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -20,6 +21,17 @@ var _ = Describe("Formatter", func() {
 	It("does not return empty data", func() {
 		result := formatter.Format("some-prefix", 1024, nil)
 		Expect(result).To(HaveLen(0))
+	})
+
+	It("compresses series with zlib", func() {
+		m := make(map[metrics.MetricKey]metrics.MetricValue)
+		m[metrics.MetricKey{Name: "bar"}] = metrics.MetricValue{
+			Points: []metrics.Point{{
+				Value: 9,
+			}},
+		}
+		result := formatter.Format("foo", 1024, m)
+		Expect(string(testhelpers.Decompress(result[0]))).To(Equal(`{"series":[{"metric":"foobar","points":[[0,9.000000]],"type":"gauge"}]}`))
 	})
 
 	It("does not 'delete' points when trying to split", func() {
@@ -43,6 +55,6 @@ var _ = Describe("Formatter", func() {
 		}
 		result := formatter.Format("some-prefix", 1024, m)
 
-		Expect(string(result[0])).To(ContainSubstring(`"metric":"bosh.healthmonitor.foo"`))
+		Expect(string(testhelpers.Decompress(result[0]))).To(ContainSubstring(`"metric":"bosh.healthmonitor.foo"`))
 	})
 })

--- a/datadogfirehosenozzle/datadog_firehose_nozzle_test.go
+++ b/datadogfirehosenozzle/datadog_firehose_nozzle_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
 
 			var payload datadogclient.Payload
-			err := json.Unmarshal(contents, &payload)
+			err := json.Unmarshal(Decompress(contents), &payload)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(payload.Series).To(HaveLen(23)) // +3 is because of the internal metrics
 		}, 2)
@@ -144,7 +144,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
 
 			var payload datadogclient.Payload
-			err := json.Unmarshal(contents, &payload)
+			err := json.Unmarshal(Decompress(contents), &payload)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(payload.Series).To(HaveLen(23))
 
@@ -152,7 +152,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 
 			// Wait a bit more for the new tick. We should receive only internal metrics
 			Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
-			err = json.Unmarshal(contents, &payload)
+			err = json.Unmarshal(Decompress(contents), &payload)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(payload.Series).To(HaveLen(3)) // only internal metrics
 
@@ -183,7 +183,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			Eventually(fakeDatadogAPI.ReceivedContents).Should(Receive(&contents))
 
 			var payload datadogclient.Payload
-			err := json.Unmarshal(contents, &payload)
+			err := json.Unmarshal(Decompress(contents), &payload)
 			Expect(err).ToNot(HaveOccurred())
 
 			slowConsumerMetric := findSlowConsumerMetric(payload)
@@ -221,7 +221,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			Eventually(fakeDatadogAPI.ReceivedContents).Should(Receive(&contents))
 
 			var payload datadogclient.Payload
-			err := json.Unmarshal(contents, &payload)
+			err := json.Unmarshal(Decompress(contents), &payload)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(payload.Series).To(HaveLen(23))
 
@@ -234,7 +234,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			// Nozzle should have reconnected.
 			// Wait a bit more for the new tick. We should receive only internal metrics
 			Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
-			err = json.Unmarshal(contents, &payload)
+			err = json.Unmarshal(Decompress(contents), &payload)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(payload.Series).To(HaveLen(3)) // only internal metrics
 			validateMetrics(payload, 10, 23)
@@ -267,7 +267,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			Eventually(fakeDatadogAPI.ReceivedContents).Should(Receive(&contents))
 
 			var payload datadogclient.Payload
-			err := json.Unmarshal(contents, &payload)
+			err := json.Unmarshal(Decompress(contents), &payload)
 			Expect(err).ToNot(HaveOccurred())
 
 			slowConsumerMetric := findSlowConsumerMetric(payload)
@@ -302,7 +302,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 				Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
 
 				var payload datadogclient.Payload
-				err := json.Unmarshal(contents, &payload)
+				err := json.Unmarshal(Decompress(contents), &payload)
 				Expect(err).ToNot(HaveOccurred())
 
 				slowConsumerMetric := findSlowConsumerMetric(payload)
@@ -339,7 +339,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 				Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
 
 				var payload datadogclient.Payload
-				err := json.Unmarshal(contents, &payload)
+				err := json.Unmarshal(Decompress(contents), &payload)
 				Expect(err).ToNot(HaveOccurred())
 
 				slowConsumerMetric := findSlowConsumerMetric(payload)
@@ -350,7 +350,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 				Expect(fakeBuffer.GetContent()).To(ContainSubstring("We've intercepted an upstream message which indicates that the nozzle or the TrafficController is not keeping up. Please try scaling up the nozzle."))
 
 				Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
-				err = json.Unmarshal(contents, &payload)
+				err = json.Unmarshal(Decompress(contents), &payload)
 				Expect(err).ToNot(HaveOccurred())
 
 				slowConsumerMetric = findSlowConsumerMetric(payload)
@@ -552,7 +552,7 @@ func filterOutNozzleMetrics(deployment string, c <-chan []byte) <-chan []byte {
 	result := make(chan []byte)
 	go func() {
 		for b := range c {
-			if !strings.Contains(string(b), filter) {
+			if !strings.Contains(string(Decompress(b)), filter) {
 				result <- b
 			}
 		}

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -113,7 +113,7 @@ var _ = Describe("DatadogFirehoseNozzle", func() {
 
 		// Break JSON blob into a list of blobs, one for each metric
 		var payload datadogclient.Payload
-		err := json.Unmarshal(messageBytes, &payload)
+		err := json.Unmarshal(Decompress(messageBytes), &payload)
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, metric := range payload.Series {

--- a/testhelpers/decompressZlib.go
+++ b/testhelpers/decompressZlib.go
@@ -1,0 +1,14 @@
+package testhelpers
+
+import (
+	"bytes"
+	"compress/zlib"
+	"io/ioutil"
+)
+
+func Decompress(src []byte) []byte {
+	r, _ := zlib.NewReader(bytes.NewReader(src))
+	defer r.Close()
+	dst, _ := ioutil.ReadAll(r)
+	return dst
+}


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Compress metric payloads using zlib

### Motivation

Payloads could get too big and get dropped. Will also increase performance since API calls will be faster.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
