### PR TITLE
Add environment variable for configuring cache refresh interval

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	defaultGrabInterval         int    = 10
 	defaultWorkers              int    = 4
 	defaultIdleTimeoutSeconds   uint32 = 60
 	defaultWorkerTimeoutSeconds uint32 = 10
@@ -88,6 +89,10 @@ func Parse(configPath string) (*Config, error) {
 
 	if config.MetricPrefix == "" {
 		config.MetricPrefix = "cloudfoundry.nozzle."
+	}
+
+	if config.GrabInterval == 0 {
+		config.GrabInterval = defaultGrabInterval
 	}
 
 	if config.NumWorkers == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,7 @@ func Parse(configPath string) (*Config, error) {
 
 	overrideWithEnvUint32("NOZZLE_FLUSHDURATIONSECONDS", &config.FlushDurationSeconds)
 	overrideWithEnvUint32("NOZZLE_FLUSHMAXBYTES", &config.FlushMaxBytes)
+	overrideWithEnvInt("NOZZLE_GRAB_INTERVAL", &config.GrabInterval)
 
 	overrideWithEnvBool("NOZZLE_INSECURESSLSKIPVERIFY", &config.InsecureSSLSkipVerify)
 	overrideWithEnvBool("NOZZLE_DISABLEACCESSCONTROL", &config.DisableAccessControl)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,6 +38,7 @@ var _ = Describe("NozzleConfig", func() {
 			"role:db",
 		}))
 		Expect(conf.EnvironmentName).To(Equal("env_name"))
+		Expect(conf.GrabInterval).To(Equal(50))
 	})
 
 	It("successfully sets default configuration values", func() {
@@ -47,6 +48,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.NumWorkers).To(BeEquivalentTo(4))
 		Expect(conf.IdleTimeoutSeconds).To(BeEquivalentTo(60))
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(10))
+		Expect(conf.GrabInterval).To(Equal(10))
 	})
 
 	It("successfully overwrites file config values with environmental variables", func() {
@@ -69,6 +71,7 @@ var _ = Describe("NozzleConfig", func() {
 		os.Setenv("NOZZLE_WORKERTIMEOUTSECONDS", "20")
 		os.Setenv("NO_PROXY", "google.com,datadoghq.com")
 		os.Setenv("NOZZLE_ENVIRONMENT_NAME", "env_var_env_name")
+		os.Setenv("NOZZLE_GRAB_INTERVAL", "50")
 
 		conf, err := Parse("testdata/test_config.json")
 		Expect(err).ToNot(HaveOccurred())
@@ -91,5 +94,6 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(20))
 		Expect(conf.DBPath).To(BeEquivalentTo("/var/vcap/nozzle.db"))
 		Expect(conf.EnvironmentName).To(Equal("env_var_env_name"))
+		Expect(conf.GrabInterval).To(Equal(50))
 	})
 })

--- a/internal/config/testdata/test_config.json
+++ b/internal/config/testdata/test_config.json
@@ -33,5 +33,6 @@
   "CustomTags": [ "nozzle:foobar", "env:prod", "role:db" ],
   "NoProxy": [ "*.aventail.com", "home.com", ".seanet.com" ],
   "DBPath": "/var/vcap/nozzle.db",
-  "EnvironmentName": "env_name"
+  "EnvironmentName": "env_name",
+  "GrabInterval": 50
 }


### PR DESCRIPTION
### What does this PR do?

Add environment variable for configuring cache refresh interval, and add default value of 10 minutes

### Motivation

Useful when not deploying the nozzle using the bosh packaging

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?