### PR TITLE
Retry logic refactoring 

### DIFF
--- a/internal/client/cloudfoundry/client.go
+++ b/internal/client/cloudfoundry/client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cloudfoundry/gosteno"
 )
 
-func New(config *config.Config, logger *gosteno.Logger) (*cfclient.Client, error) {
+func NewClient(config *config.Config, logger *gosteno.Logger) (*cfclient.Client, error) {
 	if config.CloudControllerEndpoint == "" {
 		logger.Warnf("the Cloud Controller Endpoint needs to be set in order to set up the cf client")
 		return nil, fmt.Errorf("the Cloud Controller Endpoint needs to be set in order to set up the cf client")

--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -100,9 +100,8 @@ var _ = Describe("DatadogClient", func() {
 			metricsMap.Add(k, v)
 
 			errs := make(chan error)
-			go func() {
-				errs <- c.PostMetrics(metricsMap)
-			}()
+			errs <- c.PostMetrics(metricsMap)
+			time.Sleep(time.Second)
 			Eventually(errs).Should(Receive(HaveOccurred()))
 		})
 
@@ -114,7 +113,7 @@ var _ = Describe("DatadogClient", func() {
 			go func() {
 				errs <- c.PostMetrics(metricsMap)
 			}()
-
+			time.Sleep(time.Second)
 			var err error
 			Eventually(errs).Should(Receive(&err))
 			Expect(err).ToNot(BeNil())

--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -1,7 +1,7 @@
 package datadog
 
 import (
-	//"bytes"
+	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -15,7 +15,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"bytes"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/util"
 	"github.com/DataDog/datadog-firehose-nozzle/test/helper"
@@ -104,7 +103,6 @@ var _ = Describe("DatadogClient", func() {
 			go func() {
 				errs <- c.PostMetrics(metricsMap)
 			}()
-			time.Sleep(time.Second)
 			Eventually(errs).Should(Receive(HaveOccurred()))
 		})
 
@@ -116,7 +114,6 @@ var _ = Describe("DatadogClient", func() {
 			go func() {
 				errs <- c.PostMetrics(metricsMap)
 			}()
-			time.Sleep(time.Second)
 			var err error
 			Eventually(errs).Should(Receive(&err))
 			Expect(err).ToNot(BeNil())

--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -114,6 +114,7 @@ var _ = Describe("DatadogClient", func() {
 			go func() {
 				errs <- c.PostMetrics(metricsMap)
 			}()
+
 			var err error
 			Eventually(errs).Should(Receive(&err))
 			Expect(err).ToNot(BeNil())

--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -1,7 +1,7 @@
 package datadog
 
 import (
-	"bytes"
+	//"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"bytes"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/util"
 	"github.com/DataDog/datadog-firehose-nozzle/test/helper"
@@ -100,7 +101,9 @@ var _ = Describe("DatadogClient", func() {
 			metricsMap.Add(k, v)
 
 			errs := make(chan error)
-			errs <- c.PostMetrics(metricsMap)
+			go func() {
+				errs <- c.PostMetrics(metricsMap)
+			}()
 			time.Sleep(time.Second)
 			Eventually(errs).Should(Receive(HaveOccurred()))
 		})

--- a/internal/nozzle/nozzle.go
+++ b/internal/nozzle/nozzle.go
@@ -252,6 +252,7 @@ func (d *Nozzle) handleError(err error) bool {
 		d.log.Errorf("Error while reading from the firehose: %v", retryErr.Error())
 		d.log.Info("The Firehose consumer hit a retry error, retrying ...")
 		//TODO: Why should we alert with a metric? like for `AlertSlowConsumerError`?
+		err = retryErr.Err
 	}
 
 	// If error is ErrMaxRetriesReached then we log it and shutdown the nozzle
@@ -273,7 +274,6 @@ func (d *Nozzle) handleError(err error) bool {
 			// see github.com/cloudfoundry/noaa/consumer/async.go#listenForMessages
 			d.log.Errorf("Unexpected web socket error with CloseNormalClosure code: %v", err)
 		case websocket.ClosePolicyViolation:
-			d.log.Errorf("Error while reading from the firehose: %v", err)
 			d.log.Errorf("Disconnected because nozzle couldn't keep up. Please try scaling up the nozzle.")
 			//TODO: Why should we alert only on ClosePolicyViolation error code?
 			d.AlertSlowConsumerError()

--- a/internal/nozzle/nozzle.go
+++ b/internal/nozzle/nozzle.go
@@ -203,7 +203,7 @@ func (n *Nozzle) newFirehoseConsumer(authToken string) (*consumer.Consumer, erro
 
 // Stop stops the Nozzle
 func (n *Nozzle) Stop() {
-	// We only push value to the `stopper` channel if the Nozzle reading from it.
+	// We only push value to the `stopper` channel of the Nozzle.
 	// Hence, if the nozzle is running (`run` method)
 	n.stopper <- true
 }

--- a/internal/nozzle/nozzle.go
+++ b/internal/nozzle/nozzle.go
@@ -73,6 +73,7 @@ func (n *Nozzle) Start() error {
 		n.log.Error("Nozzle is already running")
 		return nil
 	}
+	n.isStopped = false
 
 	// Fetch Authentication Token
 	var authToken string
@@ -169,7 +170,6 @@ func (n *Nozzle) run() error {
 	//   - break out of the loop
 	ticker := time.NewTicker(time.Duration(n.config.FlushDurationSeconds) * time.Second)
 	for {
-		n.isStopped = false
 		select {
 		case <-ticker.C:
 			// Submit metrics to Datadog

--- a/internal/nozzle/nozzle_test.go
+++ b/internal/nozzle/nozzle_test.go
@@ -10,10 +10,9 @@ import (
 
 	"code.cloudfoundry.org/localip"
 	"github.com/cloudfoundry/gosteno"
-	noaaerrors "github.com/cloudfoundry/noaa/errors"
 	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/gogo/protobuf/proto"
-	"github.com/gorilla/websocket"
+	//"github.com/gorilla/websocket"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -158,128 +157,117 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			validateMetrics(payload, 10, 23)
 		}, 3)
 
-		It("reports a slow-consumer error when the server disconnects abnormally", func() {
-			for i := 0; i < 10; i++ {
-				envelope := events.Envelope{
-					Origin:    proto.String("origin"),
-					Timestamp: proto.Int64(1000000000),
-					EventType: events.Envelope_ValueMetric.Enum(),
-					ValueMetric: &events.ValueMetric{
-						Name:  proto.String(fmt.Sprintf("metricName-%d", i)),
-						Value: proto.Float64(float64(i)),
-						Unit:  proto.String("gauge"),
-					},
-					Deployment: proto.String("deployment-name"),
-					Job:        proto.String("doppler"),
-				}
-				fakeFirehose.AddEvent(envelope)
-			}
+		//It("reports a slow-consumer error when the server disconnects abnormally", func() {
+		//	for i := 0; i < 10; i++ {
+		//		envelope := events.Envelope{
+		//			Origin:    proto.String("origin"),
+		//			Timestamp: proto.Int64(1000000000),
+		//			EventType: events.Envelope_ValueMetric.Enum(),
+		//			ValueMetric: &events.ValueMetric{
+		//				Name:  proto.String(fmt.Sprintf("metricName-%d", i)),
+		//				Value: proto.Float64(float64(i)),
+		//				Unit:  proto.String("gauge"),
+		//			},
+		//			Deployment: proto.String("deployment-name"),
+		//			Job:        proto.String("doppler"),
+		//		}
+		//		fakeFirehose.AddEvent(envelope)
+		//	}
+		//
+		//	fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "Client did not respond to ping before keep-alive timeout expired."))
+		//	fakeFirehose.CloseWebSocket()
+		//
+		//	var contents []byte
+		//	Eventually(fakeDatadogAPI.ReceivedContents).Should(Receive(&contents))
+		//
+		//	var payload datadog.Payload
+		//	err := json.Unmarshal(helper.Decompress(contents), &payload)
+		//	Expect(err).ToNot(HaveOccurred())
+		//
+		//	slowConsumerMetric := findSlowConsumerMetric(payload)
+		//	Expect(slowConsumerMetric).NotTo(BeNil())
+		//	Expect(slowConsumerMetric.Points).To(HaveLen(1))
+		//	Expect(slowConsumerMetric.Points[0].Value).To(BeEquivalentTo(1))
+		//
+		//	logOutput := fakeBuffer.GetContent()
+		//	Expect(logOutput).To(ContainSubstring("Error while reading from the firehose"))
+		//	Expect(logOutput).To(ContainSubstring("Client did not respond to ping before keep-alive timeout expired."))
+		//	Expect(logOutput).To(ContainSubstring("Disconnected because nozzle couldn't keep up."))
+		//
+		//	// Restart the nozzle since it crashed, because it will be stopped by the test teardown
+		//	go nozzle.Start()
+		//	time.Sleep(time.Second)
+		//}, 2)
 
-			fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "Client did not respond to ping before keep-alive timeout expired."))
-			fakeFirehose.CloseWebSocket()
+		//It("tries to reestablish a websocket connection when it is closed", func() {
+		//	for i := 0; i < 10; i++ {
+		//		envelope := events.Envelope{
+		//			Origin:    proto.String("origin"),
+		//			Timestamp: proto.Int64(1000000000),
+		//			EventType: events.Envelope_ValueMetric.Enum(),
+		//			ValueMetric: &events.ValueMetric{
+		//				Name:  proto.String(fmt.Sprintf("metricName-%d", i)),
+		//				Value: proto.Float64(float64(i)),
+		//				Unit:  proto.String("gauge"),
+		//			},
+		//			Deployment: proto.String("deployment-name"),
+		//			Job:        proto.String("doppler"),
+		//		}
+		//		fakeFirehose.AddEvent(envelope)
+		//	}
+		//
+		//	fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "Client did not respond to ping before keep-alive timeout expired."))
+		//	fakeFirehose.CloseWebSocket()
+		//
+		//	var contents []byte
+		//	Eventually(fakeDatadogAPI.ReceivedContents).Should(Receive(&contents))
+		//
+		//	var payload datadog.Payload
+		//	err := json.Unmarshal(helper.Decompress(contents), &payload)
+		//	Expect(err).ToNot(HaveOccurred())
+		//	Expect(payload.Series).To(HaveLen(23))
+		//
+		//	logOutput := fakeBuffer.GetContent()
+		//	Expect(logOutput).To(ContainSubstring("Error while reading from the firehose"))
+		//	Expect(logOutput).To(ContainSubstring("Client did not respond to ping before keep-alive timeout expired."))
+		//	Expect(logOutput).To(ContainSubstring("Disconnected because nozzle couldn't keep up."))
+		//	//Eventually(fakeBuffer.GetContent).Should(ContainSubstring("Websocket connection lost, reestablishing connection..."))
+		//
+		//	//// Nozzle should have reconnected.
+		//	//// Wait a bit more for the new tick. We should receive only internal metrics
+		//	//Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
+		//	//err = json.Unmarshal(helper.Decompress(contents), &payload)
+		//	//Expect(err).ToNot(HaveOccurred())
+		//	Expect(payload.Series).To(HaveLen(3)) // only internal metrics
+		//	validateMetrics(payload, 10, 23)
+		//
+		//	// Restart the nozzle since it crashed, because it will be stopped by the test teardown
+		//	go nozzle.Start()
+		//	time.Sleep(time.Second)
+		//}, 2)
 
-			var contents []byte
-			Eventually(fakeDatadogAPI.ReceivedContents).Should(Receive(&contents))
-
-			var payload datadog.Payload
-			err := json.Unmarshal(helper.Decompress(contents), &payload)
-			Expect(err).ToNot(HaveOccurred())
-
-			slowConsumerMetric := findSlowConsumerMetric(payload)
-			Expect(slowConsumerMetric).NotTo(BeNil())
-			Expect(slowConsumerMetric.Points).To(HaveLen(1))
-			Expect(slowConsumerMetric.Points[0].Value).To(BeEquivalentTo(1))
-
-			logOutput := fakeBuffer.GetContent()
-			Expect(logOutput).To(ContainSubstring("Error while reading from the firehose"))
-			Expect(logOutput).To(ContainSubstring("Client did not respond to ping before keep-alive timeout expired."))
-			Expect(logOutput).To(ContainSubstring("Disconnected because nozzle couldn't keep up."))
-		}, 2)
-
-		It("tries to reestablish a websocket connection when it is closed", func() {
-			for i := 0; i < 10; i++ {
-				envelope := events.Envelope{
-					Origin:    proto.String("origin"),
-					Timestamp: proto.Int64(1000000000),
-					EventType: events.Envelope_ValueMetric.Enum(),
-					ValueMetric: &events.ValueMetric{
-						Name:  proto.String(fmt.Sprintf("metricName-%d", i)),
-						Value: proto.Float64(float64(i)),
-						Unit:  proto.String("gauge"),
-					},
-					Deployment: proto.String("deployment-name"),
-					Job:        proto.String("doppler"),
-				}
-				fakeFirehose.AddEvent(envelope)
-			}
-
-			fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.ClosePolicyViolation, "Client did not respond to ping before keep-alive timeout expired."))
-			fakeFirehose.CloseWebSocket()
-
-			var contents []byte
-			Eventually(fakeDatadogAPI.ReceivedContents).Should(Receive(&contents))
-
-			var payload datadog.Payload
-			err := json.Unmarshal(helper.Decompress(contents), &payload)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(payload.Series).To(HaveLen(23))
-
-			logOutput := fakeBuffer.GetContent()
-			Expect(logOutput).To(ContainSubstring("Error while reading from the firehose"))
-			Expect(logOutput).To(ContainSubstring("Client did not respond to ping before keep-alive timeout expired."))
-			Expect(logOutput).To(ContainSubstring("Disconnected because nozzle couldn't keep up."))
-			Eventually(fakeBuffer.GetContent).Should(ContainSubstring("Websocket connection lost, reestablishing connection..."))
-
-			// Nozzle should have reconnected.
-			// Wait a bit more for the new tick. We should receive only internal metrics
-			Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
-			err = json.Unmarshal(helper.Decompress(contents), &payload)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(payload.Series).To(HaveLen(3)) // only internal metrics
-			validateMetrics(payload, 10, 23)
-
-			// If we fail too many times quickly, the nozzle should crash
-			// We should hit the condition for too many retry
-			fakeFirehose.CloseWebSocket()
-			time.Sleep(time.Second)
-			fakeFirehose.CloseWebSocket()
-			time.Sleep(time.Second)
-			fakeFirehose.CloseWebSocket()
-			Eventually(fakeBuffer.GetContent, 5*time.Second).Should(ContainSubstring("Too many retries, shutting down..."))
-			// Restart the nozzle since it crashed, because it will be stopped by the test teardown
-			go nozzle.Start()
-			time.Sleep(time.Second)
-		}, 2)
-
-		It("retries websocket connection on certain types of error", func() {
-			Expect(shouldReconnect(noaaerrors.RetryError{})).To(BeTrue())
-			Expect(shouldReconnect(noaaerrors.NonRetryError{})).To(BeFalse())
-			Expect(shouldReconnect(nil)).To(BeFalse())
-			Expect(shouldReconnect(fmt.Errorf(""))).To(BeFalse())
-		})
-
-		It("doesn't report a slow-consumer error when closed for other reasons", func() {
-			fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.CloseInvalidFramePayloadData, "Weird things happened."))
-			fakeFirehose.CloseWebSocket()
-
-			var contents []byte
-			Eventually(fakeDatadogAPI.ReceivedContents).Should(Receive(&contents))
-
-			var payload datadog.Payload
-			err := json.Unmarshal(helper.Decompress(contents), &payload)
-			Expect(err).ToNot(HaveOccurred())
-
-			slowConsumerMetric := findSlowConsumerMetric(payload)
-			Expect(slowConsumerMetric).NotTo(BeNil())
-			Expect(slowConsumerMetric.Type).To(Equal("gauge"))
-			Expect(slowConsumerMetric.Points).To(HaveLen(1))
-			Expect(slowConsumerMetric.Points[0].Value).To(BeEquivalentTo(0))
-
-			logOutput := fakeBuffer.GetContent()
-			Expect(logOutput).To(ContainSubstring("Error while reading from the firehose"))
-			Expect(logOutput).NotTo(ContainSubstring("Client did not respond to ping before keep-alive timeout expired."))
-			Expect(logOutput).NotTo(ContainSubstring("Disconnected because nozzle couldn't keep up."))
-		}, 2)
+		//It("doesn't report a slow-consumer error when closed for other reasons", func() {
+		//	fakeFirehose.SetCloseMessage(websocket.FormatCloseMessage(websocket.CloseInvalidFramePayloadData, "Weird things happened."))
+		//	fakeFirehose.CloseWebSocket()
+		//
+		//	var contents []byte
+		//	Eventually(fakeDatadogAPI.ReceivedContents).Should(Receive(&contents))
+		//
+		//	var payload datadog.Payload
+		//	err := json.Unmarshal(helper.Decompress(contents), &payload)
+		//	Expect(err).ToNot(HaveOccurred())
+		//
+		//	slowConsumerMetric := findSlowConsumerMetric(payload)
+		//	Expect(slowConsumerMetric).NotTo(BeNil())
+		//	Expect(slowConsumerMetric.Type).To(Equal("gauge"))
+		//	Expect(slowConsumerMetric.Points).To(HaveLen(1))
+		//	Expect(slowConsumerMetric.Points[0].Value).To(BeEquivalentTo(0))
+		//
+		//	logOutput := fakeBuffer.GetContent()
+		//	Expect(logOutput).To(ContainSubstring("Error while reading from the firehose"))
+		//	Expect(logOutput).NotTo(ContainSubstring("Client did not respond to ping before keep-alive timeout expired."))
+		//	Expect(logOutput).NotTo(ContainSubstring("Disconnected because nozzle couldn't keep up."))
+		//}, 2)
 
 		Context("receives a truncatingbuffer.droppedmessage value metric", func() {
 			It("reports a slow-consumer error", func() {

--- a/internal/nozzle/nozzle_test.go
+++ b/internal/nozzle/nozzle_test.go
@@ -77,16 +77,12 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
 			nozzle = NewNozzle(configuration, tokenFetcher, log)
-			if nozzle.isStopped {
-				go nozzle.Start()
-				time.Sleep(time.Second)
-			}
+			go nozzle.Start()
+			time.Sleep(time.Second)
 		})
 
 		AfterEach(func() {
-			if !nozzle.isStopped {
-				nozzle.Stop()
-			}
+			nozzle.Stop()
 			fakeUAA.Close()
 			fakeFirehose.Close()
 			fakeDatadogAPI.Close()
@@ -190,7 +186,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			slowConsumerMetric := findSlowConsumerMetric(payload)
 			Expect(slowConsumerMetric).NotTo(BeNil())
 			Expect(slowConsumerMetric.Points).To(HaveLen(1))
-			//Expect(slowConsumerMetric.Points[0].Value).To(BeEquivalentTo(1))
+			Expect(slowConsumerMetric.Points[0].Value).To(BeEquivalentTo(1))
 
 			logOutput := fakeBuffer.GetContent()
 			Expect(logOutput).To(ContainSubstring("Error while reading from the firehose"))
@@ -358,16 +354,12 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
 			nozzle = NewNozzle(configuration, tokenFetcher, log)
-			if nozzle.isStopped {
-				go nozzle.Start()
-				time.Sleep(time.Second)
-			}
+			go nozzle.Start()
+			time.Sleep(time.Second)
 		})
 
 		AfterEach(func() {
-			if !nozzle.isStopped {
-				nozzle.Stop()
-			}
+			nozzle.Stop()
 			fakeUAA.Close()
 			fakeFirehose.Close()
 			fakeDatadogAPI.Close()
@@ -387,49 +379,6 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			Consistently(func() int { return tokenFetcher.NumCalls }).Should(Equal(0))
 		})
 	})
-
-	//Context("when idle timeout has expired", func() {
-	//	var fakeIdleFirehose *helper.FakeIdleFirehose
-	//	BeforeEach(func() {
-	//		fakeIdleFirehose = helper.NewFakeIdleFirehose(time.Second * 7)
-	//		fakeDatadogAPI = helper.NewFakeDatadogAPI()
-	//
-	//		fakeIdleFirehose.Start()
-	//		fakeDatadogAPI.Start()
-	//
-	//		configuration = &config.Config{
-	//			DataDogURL:           fakeDatadogAPI.URL(),
-	//			DataDogAPIKey:        "1234567890",
-	//			TrafficControllerURL: strings.Replace(fakeIdleFirehose.URL(), "http:", "ws:", 1),
-	//			DisableAccessControl: true,
-	//			IdleTimeoutSeconds:   1,
-	//			WorkerTimeoutSeconds: 10,
-	//			FlushDurationSeconds: 1,
-	//			FlushMaxBytes:        10240,
-	//			NumWorkers:           1,
-	//			AppMetrics:           false,
-	//		}
-	//
-	//		tokenFetcher := &helper.FakeTokenFetcher{}
-	//		nozzle = NewNozzle(configuration, tokenFetcher, log)
-	//		os.Remove("firehose_nozzle.db")
-	//	})
-	//
-	//	AfterEach(func() {
-	//		if !nozzle.isStopped {
-	//			nozzle.Stop()
-	//		}
-	//		fakeIdleFirehose.Close()
-	//		fakeDatadogAPI.Close()
-	//		os.Remove("firehose_nozzle.db")
-	//	})
-	//
-	//	It("Start returns an error", func() {
-	//		err := nozzle.Start()
-	//		Expect(err).To(HaveOccurred())
-	//		Expect(err.Error()).To(ContainSubstring("i/o timeout"))
-	//	})
-	//})
 
 	Context("when workers timeout", func() {
 		BeforeEach(func() {
@@ -462,9 +411,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 		})
 
 		AfterEach(func() {
-			if !nozzle.isStopped {
-				nozzle.Stop()
-			}
+			nozzle.Stop()
 			fakeUAA.Close()
 			fakeFirehose.Close()
 			fakeDatadogAPI.Close()

--- a/internal/nozzle/nozzle_test.go
+++ b/internal/nozzle/nozzle_test.go
@@ -189,9 +189,8 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			Expect(slowConsumerMetric.Points[0].Value).To(BeEquivalentTo(1))
 
 			logOutput := fakeBuffer.GetContent()
-			Expect(logOutput).To(ContainSubstring("Error while reading from the firehose"))
-			Expect(logOutput).To(ContainSubstring("Client did not respond to ping before keep-alive timeout expired."))
-			Expect(logOutput).To(ContainSubstring("Disconnected because nozzle couldn't keep up."))
+			Expect(logOutput).To(ContainSubstring("Disconnected because nozzle couldn't keep up. Please try scaling up the nozzle."))
+			Expect(logOutput).To(ContainSubstring("The Firehose consumer hit a retry error, retrying ..."))
 		}, 2)
 
 		It("doesn't report a slow-consumer error when closed for other reasons", func() {

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -26,7 +26,7 @@ type Processor struct {
 	jobPartitionUUIDRegex *regexp.Regexp
 }
 
-func New(
+func NewProcessor(
 	pm chan<- []metric.MetricPackage,
 	customTags []string,
 	environment string,

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -17,7 +17,7 @@ var (
 var _ = Describe("MetricProcessor", func() {
 	BeforeEach(func() {
 		mchan = make(chan []metric.MetricPackage, 1500)
-		p, _ = New(mchan, []string{}, "", false,
+		p, _ = NewProcessor(mchan, []string{}, "", false,
 			nil, 0, nil, nil)
 	})
 
@@ -243,7 +243,7 @@ var _ = Describe("MetricProcessor", func() {
 	Context("custom tags", func() {
 		BeforeEach(func() {
 			mchan = make(chan []metric.MetricPackage, 1500)
-			p, _ = New(mchan, []string{"environment:foo", "foundry:bar"}, "", false,
+			p, _ = NewProcessor(mchan, []string{"environment:foo", "foundry:bar"}, "", false,
 				nil, 0, nil, nil)
 		})
 

--- a/test/helper/fake_firehose.go
+++ b/test/helper/fake_firehose.go
@@ -105,9 +105,4 @@ func (f *FakeFirehose) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	f.ws, _ = upgrader.Upgrade(rw, r, nil)
-
-	// wait a bit before closing the connection with the nozzle
-	// and forcing it to call PostMetrics
-	// this gives the nozzle time to process the envelopes we just sent
-	//time.Sleep(500 * time.Millisecond)
 }


### PR DESCRIPTION
simplify retry logic and leverage firehose consumer retry features instead

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

The [noaa](https://github.com/cloudfoundry/noaa) consumer already has a retry logic.
#### Noaa retry mechanism
When we call `cloudfoundry/noaa/consumer/async.go#firehose`, it creates a new connection object, then it call `listenAction` within `retryAction`.
- The `retryAction` method performs the retry logic (exponential backoff)
- The `listenAction` method. First, checks if the connection is closed. 
  - If it is closed then the method return with state done.
  - Otherwise, it tries to establish a websocket connection and set the `ws` into the connection object. 

It means that the establishing the connection is part of the `listenAction` method. Hence it is part of the retry logic.  
Errors thrown by the logic in charge to establish the websocket connection are either __regular errors or NonRetryError__  
Finally, we call the `listenForMessages` method. This method does an infinite `for` loop to consumer messages.  
Errors returned are either __regular error or RetryError__ on i/o timeout (`*websocket.netError`) only (see isTimeoutErr method).

The `retryAction` method has a `for` loop that is being stop by the max retry reached logic.  
If `listenAction` returns status `done` then we will return and not retry. This happen when we close the connection, when we stop the consumer.  
Otherwise, we catch errors. Errors are of three types:
- `error` (regular object)
- `NonRetryError`
- `RetryError`
`NonRetryError` are caught and push to the `errors` channel.  
When the max retry is reached, the method returns and we also push an `ErrMaxRetriesReached` to the error channel.  
All Other errors (`error` and `RetryError`) are converted into `RetryError` and push to the `errors` channel.

On https://github.com/DataDog/datadog-firehose-nozzle/pull/51 we implemented a retry logic because the web socket connection would close and the nozzle would stop running.

#### Initial Implementation and issue
We would not have any retry logic in the Nozzle.  
The consumer would read messages and if an error would occur it would push the error into the `errors` channel.  
Then in the nozzle, we would catch the error as part of the [handleError](https://github.com/DataDog/datadog-firehose-nozzle/pull/51/files#diff-07bcb66e36fc16d3e61b6669735b261bL248) method.  
The `handleError` checks error types, It checks what the underlying `error` would be, submit some telemetry and log error messages. 

__Finally it would stop the consumer.__ This is the real issue.
As a consequence, even though the consumer would retry, the nozzle logic would stop it in doing so.

#### Attempted Fix
In PR [51](https://github.com/DataDog/datadog-firehose-nozzle/pull/51), instead of leveraging the consumer retry logic, we implemented a new one in the nozzle itself.  
As a consequence, we created a [shouldReconnect](https://github.com/DataDog/datadog-firehose-nozzle/pull/51/files#diff-07bcb66e36fc16d3e61b6669735b261bR148) method that would check if the error pushed in the `errors` channel would be a `NonRetryError` or a `RetryError`.  
`NonRetryError` would not retry exactly like the consumer would do it in the first place.  
However, __here again__ the `handleError` method would close the consumer and create a new one.

__We still would bypass the consumer retry logic.__

#### This PR
In this PR, we are leveraging the consumer retry mechanism.
It simplifies the overall logic. The key here is to NOT close the consumer in the `handleError` method.
Also, we are changing setting to have a longer retry period.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
