### PR TITLE
Get list of all apps at startup time to build cache

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fdafbdd4491bbf4846d857781c5a0405963f258b74100df95b94331ce2607709
-updated: 2019-07-05T14:04:37.716119+02:00
+hash: e66a920a8e158e77f11f0f0f943bb51d577b5120c50a6e41edf5919b07fb6687
+updated: 2019-07-16T16:02:48.841011+02:00
 imports:
 - name: code.cloudfoundry.org/localip
   version: b88ad0dea95cd41f302cf7eb6ed951efafaf47f2
@@ -40,7 +40,7 @@ imports:
 - name: github.com/hashicorp/go-cleanhttp
   version: 3573b8b52aa7b37b9358d966a898feb387f62437
 - name: github.com/hashicorp/go-retryablehttp
-  version: 794af36148bf63c118d6db80eb902a136b907e71
+  version: 85a8ee556d7323a4faf0f4c17ee900e9ff1482e8
 - name: github.com/Masterminds/semver
   version: c84ddcca87bf5a941b138dde832a7e20b0159ad8
 - name: github.com/pkg/errors

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9037904c768084e7010eafb4c7155b54ebe9be330793bf1763b241a945a7ba7f
-updated: 2018-11-27T12:25:40.806287-05:00
+hash: fdafbdd4491bbf4846d857781c5a0405963f258b74100df95b94331ce2607709
+updated: 2019-07-05T14:04:37.716119+02:00
 imports:
 - name: code.cloudfoundry.org/localip
   version: b88ad0dea95cd41f302cf7eb6ed951efafaf47f2
@@ -44,7 +44,7 @@ imports:
 - name: github.com/Masterminds/semver
   version: c84ddcca87bf5a941b138dde832a7e20b0159ad8
 - name: github.com/pkg/errors
-  version: c605e284fe17294bda444b34710735b29d1a9d90
+  version: ba968bfe8b2f7e042a574c888954fccecfa385b4
 - name: golang.org/x/net
   version: db8e4de5b2d6653f66aea53094624468caad15d2
   subpackages:
@@ -57,10 +57,6 @@ imports:
   subpackages:
   - clientcredentials
   - internal
-- name: golang.org/x/sys
-  version: 39e3dc274464e7d2f663aa606a830611bae5f1db
-  subpackages:
-  - unix
 - name: google.golang.org/appengine
   version: 9d8544a6b2c7df9cff240fcf92d7b2f59bc13416
   subpackages:
@@ -115,6 +111,10 @@ testImports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
+- name: golang.org/x/sys
+  version: 39e3dc274464e7d2f663aa606a830611bae5f1db
+  subpackages:
+  - unix
 - name: golang.org/x/text
   version: 6f44c5a2ea40ee3593d98cdcc905cc1fdaa660e2
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -3,10 +3,6 @@ updated: 2018-11-27T12:25:40.806287-05:00
 imports:
 - name: code.cloudfoundry.org/localip
   version: b88ad0dea95cd41f302cf7eb6ed951efafaf47f2
-- name: github.com/boltdb/bolt
-  version: 2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8
-  subpackages:
-  - '...'
 - name: github.com/cloudfoundry-community/go-cfclient
   version: b75ec7d52c9cd9b691cf80da587d076afbed4957
 - name: github.com/cloudfoundry-incubator/uaago
@@ -29,10 +25,6 @@ imports:
   version: 78019103037ae46207993c8816e970d85bf1a9e4
   subpackages:
   - events
-- name: github.com/coreos/bbolt
-  version: 7ee3ded59d4835e10f3e7d0f7603c42aa5e83820
-  subpackages:
-  - '...'
 - name: github.com/gogo/protobuf
   version: 100ba4e885062801d56799d78530b73b178a78f3
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,6 +25,7 @@ import:
 - package: github.com/gorilla/websocket
   version: ~1.4.0
 - package: github.com/hashicorp/go-retryablehttp
+  version: ~0.5.4
 testImport:
 - package: github.com/onsi/ginkgo
   version: ~1.7.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,6 +20,8 @@ import:
   - proto
 - package: github.com/cloudfoundry-community/go-cfclient
   version: b75ec7d52c9cd9b691cf80da587d076afbed4957
+- package: github.com/pkg/errors
+  version: ~0.8.0
 - package: github.com/gorilla/websocket
   version: ~1.4.0
 - package: github.com/hashicorp/go-retryablehttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,14 +22,6 @@ import:
   version: b75ec7d52c9cd9b691cf80da587d076afbed4957
 - package: github.com/gorilla/websocket
   version: ~1.4.0
-- package: github.com/coreos/bbolt
-  version: ^1.3.1-coreos.6
-  subpackages:
-  - '...'
-- package: github.com/boltdb/bolt
-  version: ^1.3.1
-  subpackages:
-  - '...'
 - package: github.com/hashicorp/go-retryablehttp
 testImport:
 - package: github.com/onsi/ginkgo

--- a/internal/client/datadog/client.go
+++ b/internal/client/datadog/client.go
@@ -78,7 +78,7 @@ func New(
 	// Discard the http client's log and attach our hook for logging request retry attempts
 	buffer := new(bytes.Buffer)
 	httpClient.Logger = log.New(buffer, "", log.Lshortfile)
-	httpClient.RequestLogHook = func(l *log.Logger, req *http.Request, attemptNum int) {
+	httpClient.RequestLogHook = func(l retryablehttp.Logger, req *http.Request, attemptNum int) {
 		if attemptNum == 0 {
 			return
 		}
@@ -177,7 +177,7 @@ func (c *Client) PostMetrics(metrics metric.MetricsMap) error {
 func (c *Client) postMetrics(seriesBytes []byte) error {
 	url := c.seriesURL()
 
-	req, err := retryablehttp.NewRequest("POST", url, bytes.NewReader(seriesBytes))
+	req, err := retryablehttp.NewRequest("POST", url, seriesBytes)
 	if err != nil {
 		return err
 	}

--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -99,24 +99,16 @@ var _ = Describe("DatadogClient", func() {
 			k, v := makeFakeMetric("metricName", 1000, 5, events.Envelope_ValueMetric, defaultTags)
 			metricsMap.Add(k, v)
 
-			errs := make(chan error)
-			go func() {
-				errs <- c.PostMetrics(metricsMap)
-			}()
-			Eventually(errs).Should(Receive(HaveOccurred()))
+			err := c.PostMetrics(metricsMap)
+			Expect(err).ToNot(BeNil())
 		})
 
 		It("attempts to retry the connection", func() {
 			k, v := makeFakeMetric("metricName", 1000, 5, events.Envelope_ValueMetric, defaultTags)
 			metricsMap.Add(k, v)
 
-			errs := make(chan error)
-			go func() {
-				errs <- c.PostMetrics(metricsMap)
-			}()
+			err := c.PostMetrics(metricsMap)
 
-			var err error
-			Eventually(errs).Should(Receive(&err))
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("giving up after 4 attempts"))
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,8 +94,8 @@ func Parse(configPath string) (*Config, error) {
 		config.NumWorkers = defaultWorkers
 	}
 
-	if config.NumWorkers == 0 {
-		config.NumWorkers = defaultWorkers
+	if config.NumCacheWorkers == 0 {
+		config.NumCacheWorkers = defaultWorkers
 	}
 
 	if config.IdleTimeoutSeconds == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,6 @@ type Config struct {
 	NumWorkers                 int
 	GrabInterval               int
 	CustomTags                 []string
-	DBPath                     string
 	EnvironmentName            string
 	WorkerTimeoutSeconds       uint32
 }
@@ -82,7 +81,6 @@ func Parse(configPath string) (*Config, error) {
 	overrideWithEnvUint32("NOZZLE_IDLETIMEOUTSECONDS", &config.IdleTimeoutSeconds)
 	overrideWithEnvUint32("NOZZLE_WORKERTIMEOUTSECONDS", &config.WorkerTimeoutSeconds)
 	overrideWithEnvSliceStrings("NO_PROXY", &config.NoProxy)
-	overrideWithEnvVar("NOZZLE_DB_PATH", &config.DBPath)
 	overrideWithEnvVar("NOZZLE_ENVIRONMENT_NAME", &config.EnvironmentName)
 
 	if config.MetricPrefix == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ const (
 	defaultWorkerTimeoutSeconds uint32 = 10
 )
 
+// Config contains all the config parameters
 type Config struct {
 	UAAURL                     string
 	Client                     string
@@ -39,12 +40,14 @@ type Config struct {
 	IdleTimeoutSeconds         uint32
 	AppMetrics                 bool
 	NumWorkers                 int
+	NumCacheWorkers            int
 	GrabInterval               int
 	CustomTags                 []string
 	EnvironmentName            string
 	WorkerTimeoutSeconds       uint32
 }
 
+// Parse parses the config from the json configuration and environment variables
 func Parse(configPath string) (*Config, error) {
 	configBytes, err := ioutil.ReadFile(configPath)
 	var config Config
@@ -91,6 +94,10 @@ func Parse(configPath string) (*Config, error) {
 		config.NumWorkers = defaultWorkers
 	}
 
+	if config.NumWorkers == 0 {
+		config.NumWorkers = defaultWorkers
+	}
+
 	if config.IdleTimeoutSeconds == 0 {
 		config.IdleTimeoutSeconds = defaultIdleTimeoutSeconds
 	}
@@ -100,6 +107,7 @@ func Parse(configPath string) (*Config, error) {
 	}
 
 	overrideWithEnvInt("NOZZLE_NUM_WORKERS", &config.NumWorkers)
+	overrideWithEnvInt("NOZZLE_NUM_CACHE_WORKERS", &config.NumCacheWorkers)
 
 	return &config, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,7 +89,6 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.DeploymentFilter).To(Equal("env-deployment-filter"))
 		Expect(conf.DisableAccessControl).To(Equal(true))
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(20))
-		Expect(conf.DBPath).To(BeEquivalentTo("/var/vcap/nozzle.db"))
 		Expect(conf.EnvironmentName).To(Equal("env_var_env_name"))
 	})
 })

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,6 +38,8 @@ var _ = Describe("NozzleConfig", func() {
 			"role:db",
 		}))
 		Expect(conf.EnvironmentName).To(Equal("env_name"))
+		Expect(conf.NumWorkers).To(Equal(1))
+		Expect(conf.NumCacheWorkers).To(Equal(2))
 	})
 
 	It("successfully sets default configuration values", func() {
@@ -45,6 +47,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(conf.MetricPrefix).To(Equal("cloudfoundry.nozzle."))
 		Expect(conf.NumWorkers).To(BeEquivalentTo(4))
+		Expect(conf.NumCacheWorkers).To(BeEquivalentTo(4))
 		Expect(conf.IdleTimeoutSeconds).To(BeEquivalentTo(60))
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(10))
 	})
@@ -69,6 +72,8 @@ var _ = Describe("NozzleConfig", func() {
 		os.Setenv("NOZZLE_WORKERTIMEOUTSECONDS", "20")
 		os.Setenv("NO_PROXY", "google.com,datadoghq.com")
 		os.Setenv("NOZZLE_ENVIRONMENT_NAME", "env_var_env_name")
+		os.Setenv("NOZZLE_NUM_WORKERS", "3")
+		os.Setenv("NOZZLE_NUM_CACHE_WORKERS", "5")
 
 		conf, err := Parse("testdata/test_config.json")
 		Expect(err).ToNot(HaveOccurred())
@@ -90,5 +95,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.DisableAccessControl).To(Equal(true))
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(20))
 		Expect(conf.EnvironmentName).To(Equal("env_var_env_name"))
+		Expect(conf.NumWorkers).To(Equal(3))
+		Expect(conf.NumCacheWorkers).To(Equal(5))
 	})
 })

--- a/internal/config/testdata/test_config.json
+++ b/internal/config/testdata/test_config.json
@@ -35,5 +35,5 @@
   "NoProxy": [ "*.aventail.com", "home.com", ".seanet.com" ],
   "EnvironmentName": "env_name",
   "DBPath": "/var/vcap/nozzle.db",
-  "GrabInterval": 50,
+  "GrabInterval": 50
 }

--- a/internal/config/testdata/test_config.json
+++ b/internal/config/testdata/test_config.json
@@ -30,6 +30,7 @@
   "CloudControllerEndpoint": "string",
   "AppMetrics": true,
   "NumWorkers": 1,
+  "NumCacheWorkers": 2,
   "CustomTags": [ "nozzle:foobar", "env:prod", "role:db" ],
   "NoProxy": [ "*.aventail.com", "home.com", ".seanet.com" ],
   "EnvironmentName": "env_name"

--- a/internal/config/testdata/test_config.json
+++ b/internal/config/testdata/test_config.json
@@ -35,6 +35,5 @@
   "NoProxy": [ "*.aventail.com", "home.com", ".seanet.com" ],
   "EnvironmentName": "env_name",
   "DBPath": "/var/vcap/nozzle.db",
-  "EnvironmentName": "env_name",
   "GrabInterval": 50,
 }

--- a/internal/config/testdata/test_config.json
+++ b/internal/config/testdata/test_config.json
@@ -32,6 +32,5 @@
   "NumWorkers": 1,
   "CustomTags": [ "nozzle:foobar", "env:prod", "role:db" ],
   "NoProxy": [ "*.aventail.com", "home.com", ".seanet.com" ],
-  "DBPath": "/var/vcap/nozzle.db",
   "EnvironmentName": "env_name"
 }

--- a/internal/nozzle/nozzle.go
+++ b/internal/nozzle/nozzle.go
@@ -95,6 +95,7 @@ func (n *Nozzle) Start() error {
 		n.config.EnvironmentName,
 		n.parseAppMetricsEnable,
 		n.cfClient,
+		n.config.NumCacheWorkers,
 		n.config.GrabInterval,
 		n.log)
 

--- a/internal/nozzle/nozzle.go
+++ b/internal/nozzle/nozzle.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cloudfoundry/noaa/consumer"
 	noaaerrors "github.com/cloudfoundry/noaa/errors"
 	"github.com/cloudfoundry/sonde-go/events"
-	bolt "github.com/coreos/bbolt"
 	"github.com/gorilla/websocket"
 )
 
@@ -33,7 +32,6 @@ type Nozzle struct {
 	cfClient              *cfclient.Client
 	processedMetrics      chan []metric.MetricPackage
 	log                   *gosteno.Logger
-	db                    *bolt.DB
 	parseAppMetricsEnable bool
 	stopper               chan bool
 	workersStopper        chan bool
@@ -78,21 +76,10 @@ func (n *Nozzle) Start() error {
 		n.config.CustomTags = []string{}
 	}
 
-	// Initialize Bolt DB
-	var dbPath = "firehose_nozzle.db"
-	if n.config.DBPath != "" {
-		dbPath = n.config.DBPath
-	}
-	var db, err = bolt.Open(dbPath, 0666, &bolt.Options{
-		ReadOnly: false,
-	})
-	if err != nil {
-		return err
-	}
-	defer db.Close()
-	n.db = db
+	n.log.Info("Starting DataDog Firehose Nozzle...")
 
 	// Initialize Datadog client instances
+	var err error
 	n.ddClients, err = datadog.NewClients(n.config, n.log)
 	if err != nil {
 		return err
@@ -109,8 +96,7 @@ func (n *Nozzle) Start() error {
 		n.parseAppMetricsEnable,
 		n.cfClient,
 		n.config.GrabInterval,
-		n.log,
-		n.db)
+		n.log)
 
 	// Initialize the firehose consumer (with retry enable)
 	err = n.startFirehoseConsumer(authToken)

--- a/internal/nozzle/nozzle.go
+++ b/internal/nozzle/nozzle.go
@@ -47,7 +47,7 @@ type AuthTokenFetcher interface {
 	FetchAuthToken() string
 }
 
-// Nozzle creates a new nozzle
+// NewNozzle creates a new nozzle
 func NewNozzle(config *config.Config, tokenFetcher AuthTokenFetcher, log *gosteno.Logger) *Nozzle {
 	return &Nozzle{
 		config:                config,

--- a/internal/nozzle/nozzle_test.go
+++ b/internal/nozzle/nozzle_test.go
@@ -71,7 +71,6 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 				AppMetrics:           false,
 				NumWorkers:           1,
 			}
-		})
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
 			nozzle = NewNozzle(configuration, tokenFetcher, log)
@@ -345,7 +344,6 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 				NumWorkers:           1,
 				AppMetrics:           false,
 			}
-		})
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
 			nozzle = NewNozzle(configuration, tokenFetcher, log)
@@ -398,7 +396,6 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 				AppMetrics:           false,
 				NumWorkers:           1,
 			}
-		})
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
 			nozzle = NewNozzle(configuration, tokenFetcher, log)

--- a/internal/nozzle/nozzle_test.go
+++ b/internal/nozzle/nozzle_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -72,8 +71,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 				AppMetrics:           false,
 				NumWorkers:           1,
 			}
-
-			os.Remove("firehose_nozzle.db")
+		})
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
 			nozzle = NewNozzle(configuration, tokenFetcher, log)
@@ -86,7 +84,6 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			fakeUAA.Close()
 			fakeFirehose.Close()
 			fakeDatadogAPI.Close()
-			os.Remove("firehose_nozzle.db")
 		})
 
 		It("receives data from the firehose", func() {
@@ -348,8 +345,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 				NumWorkers:           1,
 				AppMetrics:           false,
 			}
-
-			os.Remove("firehose_nozzle.db")
+		})
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
 			nozzle = NewNozzle(configuration, tokenFetcher, log)
@@ -362,7 +358,6 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			fakeUAA.Close()
 			fakeFirehose.Close()
 			fakeDatadogAPI.Close()
-			os.Remove("firehose_nozzle.db")
 		})
 
 		It("can still tries to connect to the firehose", func() {
@@ -403,7 +398,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 				AppMetrics:           false,
 				NumWorkers:           1,
 			}
-			os.Remove("firehose_nozzle.db")
+		})
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
 			nozzle = NewNozzle(configuration, tokenFetcher, log)
@@ -414,7 +409,6 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			fakeUAA.Close()
 			fakeFirehose.Close()
 			fakeDatadogAPI.Close()
-			os.Remove("firehose_nozzle.db")
 		})
 
 		It("logs a warning", func() {

--- a/internal/nozzle/workers.go
+++ b/internal/nozzle/workers.go
@@ -22,6 +22,9 @@ func (d *Nozzle) startWorkers() {
 }
 
 func (d *Nozzle) stopWorkers() {
+	// Stop the app metrics cache refreshing loop if it's started
+	d.processor.StopAppMetrics()
+
 	timedOut := false
 	for i := 0; i < d.config.NumWorkers+1; i++ {
 		// +1 is for the readProcessedMetrics worker

--- a/internal/processor/parser/app.go
+++ b/internal/processor/parser/app.go
@@ -24,21 +24,23 @@ func newAppCache() appCache {
 	}
 }
 
-func (c *appCache) Add(resolvedApp cfclient.App) *App {
+// Add inserts or update a new app in the cache, and returns it
+func (c *appCache) Add(cfApp cfclient.App) *App {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if app := c.apps[resolvedApp.Guid]; app != nil {
-		app.setAppData(resolvedApp)
+	if app := c.apps[cfApp.Guid]; app != nil {
+		app.setAppData(cfApp)
 	} else {
-		app := newApp(resolvedApp.Guid)
-		app.setAppData(resolvedApp)
-		c.apps[resolvedApp.Guid] = app
+		app := newApp(cfApp.Guid)
+		app.setAppData(cfApp)
+		c.apps[cfApp.Guid] = app
 	}
 
-	return c.apps[resolvedApp.Guid]
+	return c.apps[cfApp.Guid]
 }
 
+// Delete removes an app from the cache
 func (c *appCache) Delete(guid string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -46,6 +48,7 @@ func (c *appCache) Delete(guid string) {
 	delete(c.apps, guid)
 }
 
+// Get returns a cached app or nil if not found
 func (c *appCache) Get(guid string) *App {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/internal/processor/parser/app.go
+++ b/internal/processor/parser/app.go
@@ -230,8 +230,12 @@ func listApps(c *cfclient.Client, numWorkers int, log *gosteno.Logger) ([]cfclie
 			defer wg.Done()
 			// Offset 2 because no page 0 and page 1 already fetched
 			pageStart := i*pagesPerWorker + 2
-			// Stop at page resp.Pages, which is the last one
+			// Stop at page resp.Pages + 1, to get the last one
 			pageEnd := int(math.Min(float64((i+1)*pagesPerWorker+2), float64(resp.Pages)))
+			if pageEnd == resp.Pages {
+				// Add one so the last page can be obtained since getAppResourcesPageRange queries pages strictly less than pageEnd
+				pageEnd++
+			}
 			resources := getAppResourcesPageRange(c, pageStart, pageEnd, log)
 			mutex.Lock()
 			appResources = append(appResources, resources...)

--- a/internal/processor/parser/app.go
+++ b/internal/processor/parser/app.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"math"
 	"net/url"
+	"strconv"
 	"sync"
 	"time"
 
@@ -233,7 +234,7 @@ func getAppsPage(c *cfclient.Client, pageNb int) (*cfclient.AppResponse, error) 
 	q := url.Values{}
 	q.Set("inline-relations-depth", "2")
 	q.Set("results-per-page", "100") // 100 is the max
-	q.Set("page", string(pageNb))
+	q.Set("page", strconv.Itoa(pageNb))
 	r := c.NewRequest("GET", "/v2/apps?"+q.Encode())
 	resp, err := c.DoRequest(r)
 

--- a/internal/processor/parser/app.go
+++ b/internal/processor/parser/app.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"sync"
 	"time"
@@ -123,6 +124,7 @@ func (am *AppParser) warmupCache() {
 	for _, resolvedApp := range apps {
 		am.AppCache.Add(resolvedApp)
 	}
+	am.log.Infof("Done warming up cache")
 }
 
 func (am *AppParser) getAppData(guid string) (*App, error) {

--- a/internal/processor/parser/app_test.go
+++ b/internal/processor/parser/app_test.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
 	. "github.com/DataDog/datadog-firehose-nozzle/test/helper"
 	cfclient "github.com/cloudfoundry-community/go-cfclient"
@@ -64,20 +66,68 @@ var _ = Describe("AppMetrics", func() {
 				Expect(a.AppCache.apps).To(HaveKey(fmt.Sprintf("app-%d", i)))
 			}
 		})
+		It("requests all the apps when there are less runners than pages", func() {
+			fakeCloudControllerAPI.AppNumber = 10
+			a, err := NewAppParser(fakeCfClient, 5, 999, log, []string{}, "")
+			Expect(err).To(BeNil())
+			Expect(a).NotTo(BeNil())
+			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
+			Expect(len(a.AppCache.apps)).To(Equal(10))
+			for i := 1; i <= 10; i++ {
+				Expect(a.AppCache.apps).To(HaveKey(fmt.Sprintf("app-%d", i)))
+			}
+		})
+		It("requests all the apps when there are more runners than pages", func() {
+			fakeCloudControllerAPI.AppNumber = 2
+			a, err := NewAppParser(fakeCfClient, 5, 999, log, []string{}, "")
+			Expect(err).To(BeNil())
+			Expect(a).NotTo(BeNil())
+			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
+			Expect(len(a.AppCache.apps)).To(Equal(2))
+			for i := 1; i <= 2; i++ {
+				Expect(a.AppCache.apps).To(HaveKey(fmt.Sprintf("app-%d", i)))
+			}
+		})
+		It("requests all the apps when there are as many runners as pages", func() {
+			fakeCloudControllerAPI.AppNumber = 3
+			a, err := NewAppParser(fakeCfClient, 3, 999, log, []string{}, "")
+			Expect(err).To(BeNil())
+			Expect(a).NotTo(BeNil())
+			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
+			Expect(len(a.AppCache.apps)).To(Equal(3))
+			for i := 1; i <= 3; i++ {
+				Expect(a.AppCache.apps).To(HaveKey(fmt.Sprintf("app-%d", i)))
+			}
+		})
+		It("does not block while warming cache", func() {
+			fakeCloudControllerAPI.RequestTime = 100
+			a, err := NewAppParser(fakeCfClient, 5, 999, log, []string{}, "")
+			// Assertions are done while cache is warming up in the background
+			Expect(err).To(BeNil())
+			Expect(a).NotTo(BeNil())
+			Expect(a.AppCache.IsWarmedUp()).To(BeFalse())
+			// Eventually, the cache is ready
+			Eventually(a.AppCache.IsWarmedUp, 10*time.Second).Should(BeTrue())
+		})
 	})
 
 	Context("app metrics test", func() {
-		It("tries to get it from the cloud controller when the cache is empty", func() {
+		It("tries to get it from the cloud controller when not in the cache", func() {
 			a, _ := NewAppParser(fakeCfClient, 5, 10, log, []string{}, "")
-			_, err := a.getAppData("guid")
-			Expect(err).NotTo(BeNil())
+			_, err := a.getAppData("app-5")
+			Expect(err).ToNot(BeNil()) // error expected because fake CC won't return an app, so unmarshalling will fail
+			var req *http.Request
+			Eventually(fakeCloudControllerAPI.ReceivedRequests).Should(Receive()) // /v2/info
+			Eventually(fakeCloudControllerAPI.ReceivedRequests).Should(Receive()) // /oauth/token
+			Eventually(fakeCloudControllerAPI.ReceivedRequests).Should(Receive(&req))
+			Expect(req.URL.Path).To(Equal("/v2/apps/app-5"))
 		})
 
-		It("grabs from the cache when it should be", func() {
+		It("grabs from the cache when it present", func() {
 			a, _ := NewAppParser(fakeCfClient, 5, 10, log, []string{}, "")
-			guids := []string{"guid1", "guid2"}
-			a.AppCache = *newFakeApps(guids)
-			app, err := a.getAppData("guid1")
+			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
+			Expect(a.AppCache.apps).To(HaveKey("app-4"))
+			app, err := a.getAppData("app-4")
 			Expect(err).To(BeNil())
 			Expect(app).NotTo(BeNil())
 		})
@@ -87,8 +137,7 @@ var _ = Describe("AppMetrics", func() {
 		It("parses an event properly", func() {
 			a, err := NewAppParser(fakeCfClient, 5, 10, log, []string{}, "env_name")
 			Expect(err).To(BeNil())
-			guids := []string{"guid1", "guid2"}
-			a.AppCache = *newFakeApps(guids)
+			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
 
 			event := &events.Envelope{
 				Origin:    proto.String("test-origin"),
@@ -101,7 +150,7 @@ var _ = Describe("AppMetrics", func() {
 					DiskBytesQuota:   proto.Uint64(uint64(1)),
 					MemoryBytes:      proto.Uint64(uint64(1)),
 					MemoryBytesQuota: proto.Uint64(uint64(1)),
-					ApplicationId:    proto.String("guid1"),
+					ApplicationId:    proto.String("app-1"),
 				},
 
 				// fields that gets sent as tags
@@ -128,8 +177,8 @@ var _ = Describe("AppMetrics", func() {
 			Expect(metrics).To(ContainMetric("app.memory.quota"))
 
 			for _, metric := range metrics {
-				Expect(metric.MetricValue.Tags).To(ContainElement("app_name:guid1"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("guid:guid1"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("app_name:app-1"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("guid:app-1"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("env:env_name"))
 			}
 		})
@@ -139,8 +188,7 @@ var _ = Describe("AppMetrics", func() {
 		It("attaches custom tags if present", func() {
 			a, err := NewAppParser(fakeCfClient, 5, 10, log, []string{"custom:tag", "foo:bar"}, "env_name")
 			Expect(err).To(BeNil())
-			guids := []string{"guid1", "guid2"}
-			a.AppCache = *newFakeApps(guids)
+			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
 
 			event := &events.Envelope{
 				Origin:    proto.String("test-origin"),
@@ -153,7 +201,7 @@ var _ = Describe("AppMetrics", func() {
 					DiskBytesQuota:   proto.Uint64(uint64(1)),
 					MemoryBytes:      proto.Uint64(uint64(1)),
 					MemoryBytesQuota: proto.Uint64(uint64(1)),
-					ApplicationId:    proto.String("guid1"),
+					ApplicationId:    proto.String("app-1"),
 				},
 
 				// fields that gets sent as tags
@@ -169,8 +217,8 @@ var _ = Describe("AppMetrics", func() {
 			Expect(metrics).To(HaveLen(10))
 
 			for _, metric := range metrics {
-				Expect(metric.MetricValue.Tags).To(ContainElement("app_name:guid1"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("guid:guid1"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("app_name:app-1"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("guid:app-1"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("custom:tag"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("foo:bar"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("env:env_name"))
@@ -211,20 +259,4 @@ func (m *containMetric) FailureMessage(actual interface{}) (message string) {
 
 func (m *containMetric) NegatedFailureMessage(actual interface{}) (message string) {
 	return fmt.Sprintf("Did not expect %#v to contain a metric named %s", m.haystack, m.needle)
-}
-
-func newFakeApps(guids []string) *appCache {
-	cache := newAppCache()
-	for _, guid := range guids {
-		cache.apps[guid] = &App{
-			Name:                   guid,
-			GUID:                   guid,
-			TotalDiskConfigured:    1,
-			TotalMemoryConfigured:  1,
-			TotalDiskProvisioned:   1,
-			TotalMemoryProvisioned: 1,
-		}
-	}
-
-	return &cache
 }

--- a/internal/processor/parser/app_test.go
+++ b/internal/processor/parser/app_test.go
@@ -42,12 +42,12 @@ var _ = Describe("AppMetrics", func() {
 
 	Context("generator function", func() {
 		It("errors out properly when it cannot connect", func() {
-			_, err := NewAppParser(nil, 10, log, []string{}, "")
+			_, err := NewAppParser(nil, 5, 10, log, []string{}, "")
 			Expect(err).NotTo(BeNil())
 		})
 
 		It("generates it properly when it can connect", func() {
-			a, err := NewAppParser(fakeCfClient, 10, log, []string{}, "")
+			a, err := NewAppParser(fakeCfClient, 5, 10, log, []string{}, "")
 			Expect(err).To(BeNil())
 			Expect(a).NotTo(BeNil())
 		})
@@ -55,13 +55,13 @@ var _ = Describe("AppMetrics", func() {
 
 	Context("app metrics test", func() {
 		It("tries to get it from the cloud controller when the cache is empty", func() {
-			a, _ := NewAppParser(fakeCfClient, 10, log, []string{}, "")
+			a, _ := NewAppParser(fakeCfClient, 5, 10, log, []string{}, "")
 			_, err := a.getAppData("guid")
 			Expect(err).NotTo(BeNil())
 		})
 
 		It("grabs from the cache when it should be", func() {
-			a, _ := NewAppParser(fakeCfClient, 10, log, []string{}, "")
+			a, _ := NewAppParser(fakeCfClient, 5, 10, log, []string{}, "")
 			guids := []string{"guid1", "guid2"}
 			a.AppCache = *newFakeApps(guids)
 			app, err := a.getAppData("guid1")
@@ -72,7 +72,7 @@ var _ = Describe("AppMetrics", func() {
 
 	Context("metric evaluation test", func() {
 		It("parses an event properly", func() {
-			a, err := NewAppParser(fakeCfClient, 10, log, []string{}, "env_name")
+			a, err := NewAppParser(fakeCfClient, 5, 10, log, []string{}, "env_name")
 			Expect(err).To(BeNil())
 			guids := []string{"guid1", "guid2"}
 			a.AppCache = *newFakeApps(guids)
@@ -124,7 +124,7 @@ var _ = Describe("AppMetrics", func() {
 
 	Context("custom tags", func() {
 		It("attaches custom tags if present", func() {
-			a, err := NewAppParser(fakeCfClient, 10, log, []string{"custom:tag", "foo:bar"}, "env_name")
+			a, err := NewAppParser(fakeCfClient, 5, 10, log, []string{"custom:tag", "foo:bar"}, "env_name")
 			Expect(err).To(BeNil())
 			guids := []string{"guid1", "guid2"}
 			a.AppCache = *newFakeApps(guids)
@@ -210,7 +210,6 @@ func newFakeApps(guids []string) *appCache {
 			TotalMemoryConfigured:  1,
 			TotalDiskProvisioned:   1,
 			TotalMemoryProvisioned: 1,
-			Instances:              map[string]Instance{},
 		}
 	}
 

--- a/internal/processor/parser/app_test.go
+++ b/internal/processor/parser/app_test.go
@@ -53,6 +53,19 @@ var _ = Describe("AppMetrics", func() {
 		})
 	})
 
+	Context("cache warmup", func() {
+		It("requests all the apps directly at startup", func() {
+			a, err := NewAppParser(fakeCfClient, 5, 999, log, []string{}, "")
+			Expect(err).To(BeNil())
+			Expect(a).NotTo(BeNil())
+			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
+			Expect(len(a.AppCache.apps)).To(Equal(4))
+			for i := 1; i <= 4; i++ {
+				Expect(a.AppCache.apps).To(HaveKey(fmt.Sprintf("app-%d", i)))
+			}
+		})
+	})
+
 	Context("app metrics test", func() {
 		It("tries to get it from the cloud controller when the cache is empty", func() {
 			a, _ := NewAppParser(fakeCfClient, 5, 10, log, []string{}, "")

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -88,6 +88,15 @@ func (p *Processor) ProcessMetric(envelope *events.Envelope) {
 	}
 }
 
+// StopAppMetrics stops the goroutine refreshing the apps cache
+func (p *Processor) StopAppMetrics() {
+	if p.appMetrics == nil {
+		return
+	}
+
+	p.appMetrics.Stop()
+}
+
 func (p *Processor) parseAppMetric(envelope *events.Envelope) ([]metric.MetricPackage, error) {
 	var metricsPackages []metric.MetricPackage
 	var err error

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -115,6 +115,11 @@ func (p *Processor) parseAppMetric(envelope *events.Envelope) ([]metric.MetricPa
 		return metricsPackages, fmt.Errorf("not an app metric")
 	}
 
+	appParser := p.appMetrics.(*parser.AppParser)
+	if !appParser.AppCache.IsWarmedUp() {
+		return metricsPackages, fmt.Errorf("app metrics cache is not yet ready, skipping envelope")
+	}
+
 	metricsPackages, err = p.appMetrics.Parse(envelope)
 
 	return metricsPackages, err

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -94,7 +94,8 @@ func (p *Processor) StopAppMetrics() {
 		return
 	}
 
-	p.appMetrics.Stop()
+	appParser := p.appMetrics.(*parser.AppParser)
+	appParser.Stop()
 }
 
 func (p *Processor) parseAppMetric(envelope *events.Envelope) ([]metric.MetricPackage, error) {

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"fmt"
-	bolt "github.com/coreos/bbolt"
 	"regexp"
 
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
@@ -34,7 +33,6 @@ func NewProcessor(
 	cfClient *cfclient.Client,
 	grabInterval int,
 	log *gosteno.Logger,
-	db *bolt.DB,
 ) (*Processor, bool) {
 
 	processor := &Processor{
@@ -51,7 +49,6 @@ func NewProcessor(
 			grabInterval,
 			log,
 			customTags,
-			db,
 			environment,
 		)
 		if err != nil {

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -18,7 +18,7 @@ var _ = Describe("MetricProcessor", func() {
 	BeforeEach(func() {
 		mchan = make(chan []metric.MetricPackage, 1500)
 		p, _ = NewProcessor(mchan, []string{}, "", false,
-			nil, 0, nil)
+			nil, 4, 0, nil)
 	})
 
 	It("processes value & counter metrics", func() {
@@ -244,7 +244,7 @@ var _ = Describe("MetricProcessor", func() {
 		BeforeEach(func() {
 			mchan = make(chan []metric.MetricPackage, 1500)
 			p, _ = NewProcessor(mchan, []string{"environment:foo", "foundry:bar"}, "", false,
-				nil, 0, nil)
+				nil, 4, 0, nil)
 		})
 
 		It("adds custom tags to infra metrics", func() {

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -18,7 +18,7 @@ var _ = Describe("MetricProcessor", func() {
 	BeforeEach(func() {
 		mchan = make(chan []metric.MetricPackage, 1500)
 		p, _ = NewProcessor(mchan, []string{}, "", false,
-			nil, 0, nil, nil)
+			nil, 0, nil)
 	})
 
 	It("processes value & counter metrics", func() {
@@ -244,7 +244,7 @@ var _ = Describe("MetricProcessor", func() {
 		BeforeEach(func() {
 			mchan = make(chan []metric.MetricPackage, 1500)
 			p, _ = NewProcessor(mchan, []string{"environment:foo", "foundry:bar"}, "", false,
-				nil, 0, nil, nil)
+				nil, 0, nil)
 		})
 
 		It("adds custom tags to infra metrics", func() {

--- a/test/helper/fake_cloud_controller_api.go
+++ b/test/helper/fake_cloud_controller_api.go
@@ -5,16 +5,16 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync"
 
-	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
 // FakeCloudControllerAPI mocks a cloud controller
 type FakeCloudControllerAPI struct {
 	ReceivedContents chan []byte
-	ReceivedRequests chan cfclient.Request
+	ReceivedRequests chan *http.Request
 
 	server *httptest.Server
 	lock   sync.Mutex
@@ -35,7 +35,7 @@ type FakeCloudControllerAPI struct {
 func NewFakeCloudControllerAPI(tokenType string, accessToken string) *FakeCloudControllerAPI {
 	return &FakeCloudControllerAPI{
 		ReceivedContents: make(chan []byte, 100),
-		ReceivedRequests: make(chan cfclient.Request, 100),
+		ReceivedRequests: make(chan *http.Request, 100),
 		tokenType:        tokenType,
 		accessToken:      accessToken,
 	}
@@ -64,14 +64,11 @@ func (f *FakeCloudControllerAPI) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 
 	go func() {
 		f.ReceivedContents <- contents
+		f.ReceivedRequests <- r
 	}()
-	defer r.Body.Close()
-	rw.Write([]byte(fmt.Sprintf(`
-		{
-			"token_type": "%s",
-			"access_token": "%s"
-		}
-	`, f.tokenType, f.accessToken)))
+
+	f.writeResponse(rw, r)
+
 	f.lock.Lock()
 	f.requested = true
 	f.lock.Unlock()
@@ -83,4 +80,169 @@ func (f *FakeCloudControllerAPI) AuthToken() string {
 		return ""
 	}
 	return fmt.Sprintf("%s %s", f.tokenType, f.accessToken)
+}
+
+func (f *FakeCloudControllerAPI) writeResponse(rw http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/v2/info":
+		rw.Write([]byte(fmt.Sprintf(`
+		{
+			"name": "Small Footprint PAS",
+			"build": "2.4.7-build.16",
+			"support": "https://support.pivotal.io",
+			"version": 0,
+			"description": "https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html",
+			"authorization_endpoint": "%s",
+			"token_endpoint": "%s",
+			"min_cli_version": "6.23.0",
+			"min_recommended_cli_version": "6.23.0",
+			"api_version": "2.125.0",
+			"osbapi_version": "2.14",
+			"routing_endpoint": "%s/routing"
+		  }
+		`, f.URL(), f.URL(), f.URL())))
+	case "/v2/apps":
+		params, _ := url.ParseQuery(r.URL.RawQuery)
+		page := params["page"][0]
+		rw.Write([]byte(fmt.Sprintf(`
+		{
+			"total_results": 4,
+			"total_pages": 4,
+			"prev_url": null,
+			"next_url": "/v2/apps?inline-relations-depth=2&order-direction=asc&page=2&results-per-page=1",
+			"resources": [
+			  {
+				"metadata": {
+				  "guid": "app-%s",
+				  "url": "/v2/apps/b7f0436c-c1c7-499f-b9af-33e593a3f0ea",
+				  "created_at": "2019-05-17T15:02:39Z",
+				  "updated_at": "2019-05-21T13:51:14Z"
+				},
+				"entity": {
+				  "name": "app-%s",
+				  "production": false,
+				  "space_guid": "417b893e-291e-48ec-94c7-7b2348604365",
+				  "stack_guid": "b903564c-61ab-4555-bb01-5ed167db6e64",
+				  "buildpack": "ruby_buildpack",
+				  "detected_buildpack": "ruby",
+				  "detected_buildpack_guid": "3ddc6864-db9c-4dd4-8d15-ae690363ceb2",
+				  "environment_json": {},
+				  "memory": 1024,
+				  "instances": 1,
+				  "disk_quota": 1024,
+				  "state": "STOPPED",
+				  "version": "7ab56b40-5b6f-41b3-a731-33d5228dc94f",
+				  "command": "bundle exec rake scheduler:start",
+				  "console": false,
+				  "debug": null,
+				  "staging_task_id": "212edfb9-85d2-4f18-8a1a-901539358167",
+				  "package_state": "STAGED",
+				  "health_check_type": "process",
+				  "health_check_timeout": null,
+				  "health_check_http_endpoint": "",
+				  "staging_failed_reason": null,
+				  "staging_failed_description": null,
+				  "diego": true,
+				  "docker_image": null,
+				  "docker_credentials": {
+					"username": null,
+					"password": null
+				  },
+				  "package_updated_at": "2019-05-17T15:02:41Z",
+				  "detected_start_command": "bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV",
+				  "enable_ssh": true,
+				  "ports": [
+					8080
+				  ],
+				  "space_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365",
+				  "space": {
+					"metadata": {
+					  "guid": "417b893e-291e-48ec-94c7-7b2348604365",
+					  "url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365",
+					  "created_at": "2019-05-17T15:02:37Z",
+					  "updated_at": "2019-05-17T15:02:37Z"
+					},
+					"entity": {
+					  "name": "system",
+					  "organization_guid": "671557cf-edcd-49df-9863-ee14513d13c7",
+					  "space_quota_definition_guid": null,
+					  "isolation_segment_guid": null,
+					  "allow_ssh": true,
+					  "organization_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7",
+					  "organization": {
+						"metadata": {
+						  "guid": "671557cf-edcd-49df-9863-ee14513d13c7",
+						  "url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7",
+						  "created_at": "2019-05-17T13:06:27Z",
+						  "updated_at": "2019-05-21T13:52:13Z"
+						},
+						"entity": {
+						  "name": "system",
+						  "billing_enabled": false,
+						  "quota_definition_guid": "1cf98856-aba8-49a8-8b21-d82a25898c4e",
+						  "status": "active",
+						  "default_isolation_segment_guid": null,
+						  "quota_definition_url": "/v2/quota_definitions/1cf98856-aba8-49a8-8b21-d82a25898c4e",
+						  "spaces_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/spaces",
+						  "domains_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/domains",
+						  "private_domains_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/private_domains",
+						  "users_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/users",
+						  "managers_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/managers",
+						  "billing_managers_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/billing_managers",
+						  "auditors_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/auditors",
+						  "app_events_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/app_events",
+						  "space_quota_definitions_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/space_quota_definitions"
+						}
+					  },
+					  "developers_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/developers",
+					  "developers": [],
+					  "managers_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/managers",
+					  "managers": [],
+					  "auditors_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/auditors",
+					  "auditors": [],
+					  "apps_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/apps",
+					  "routes_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/routes",
+					  "domains_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/domains",
+					  "domains": [],
+					  "service_instances_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/service_instances",
+					  "service_instances": [],
+					  "app_events_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/app_events",
+					  "events_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/events",
+					  "security_groups_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/security_groups",
+					  "security_groups": [],
+					  "staging_security_groups_url": "/v2/spaces/417b893e-291e-48ec-94c7-7b2348604365/staging_security_groups",
+					  "staging_security_groups": []
+					}
+				  },
+				  "stack_url": "/v2/stacks/b903564c-61ab-4555-bb01-5ed167db6e64",
+				  "stack": {
+					"metadata": {
+					  "guid": "b903564c-61ab-4555-bb01-5ed167db6e64",
+					  "url": "/v2/stacks/b903564c-61ab-4555-bb01-5ed167db6e64",
+					  "created_at": "2019-05-17T13:06:27Z",
+					  "updated_at": "2019-05-17T13:06:27Z"
+					},
+					"entity": {
+					  "name": "cflinuxfs3",
+					  "description": "Cloud Foundry Linux-based filesystem - Ubuntu Bionic 18.04 LTS"
+					}
+				  },
+				  "routes_url": "/v2/apps/b7f0436c-c1c7-499f-b9af-33e593a3f0ea/routes",
+				  "routes": [],
+				  "events_url": "/v2/apps/b7f0436c-c1c7-499f-b9af-33e593a3f0ea/events",
+				  "service_bindings_url": "/v2/apps/b7f0436c-c1c7-499f-b9af-33e593a3f0ea/service_bindings",
+				  "service_bindings": [],
+				  "route_mappings_url": "/v2/apps/b7f0436c-c1c7-499f-b9af-33e593a3f0ea/route_mappings"
+				}
+			  }
+			]
+		  }`, page, page)))
+	default:
+		rw.Write([]byte(fmt.Sprintf(`
+		{
+			"token_type": "%s",
+			"access_token": "%s"
+		}
+		`, f.tokenType, f.accessToken)))
+	}
 }

--- a/test/helper/fake_cloud_controller_api.go
+++ b/test/helper/fake_cloud_controller_api.go
@@ -7,11 +7,14 @@ import (
 	"net/http/httptest"
 	"sync"
 
+	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/cloudfoundry/sonde-go/events"
 )
 
+// FakeCloudControllerAPI mocks a cloud controller
 type FakeCloudControllerAPI struct {
 	ReceivedContents chan []byte
+	ReceivedRequests chan cfclient.Request
 
 	server *httptest.Server
 	lock   sync.Mutex
@@ -28,27 +31,33 @@ type FakeCloudControllerAPI struct {
 	closeMessage []byte
 }
 
+// NewFakeCloudControllerAPI create a new cloud controller
 func NewFakeCloudControllerAPI(tokenType string, accessToken string) *FakeCloudControllerAPI {
 	return &FakeCloudControllerAPI{
 		ReceivedContents: make(chan []byte, 100),
+		ReceivedRequests: make(chan cfclient.Request, 100),
 		tokenType:        tokenType,
 		accessToken:      accessToken,
 	}
 }
 
+// Start starts the cloud controller
 func (f *FakeCloudControllerAPI) Start() {
 	f.server = httptest.NewUnstartedServer(f)
 	f.server.Start()
 }
 
+// Close closes the cloud controller
 func (f *FakeCloudControllerAPI) Close() {
 	f.server.Close()
 }
 
+// URL returns the API url
 func (f *FakeCloudControllerAPI) URL() string {
 	return f.server.URL
 }
 
+// ServeHTTP listens for http requests
 func (f *FakeCloudControllerAPI) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	contents, _ := ioutil.ReadAll(r.Body)
 	defer r.Body.Close()
@@ -68,6 +77,7 @@ func (f *FakeCloudControllerAPI) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 	f.lock.Unlock()
 }
 
+// AuthToken returns auth token
 func (f *FakeCloudControllerAPI) AuthToken() string {
 	if f.tokenType == "" && f.accessToken == "" {
 		return ""

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -21,8 +20,6 @@ var pathToNozzleExecutable string
 var _ = BeforeSuite(func() {
 	var err error
 	pathToNozzleExecutable, err = gexec.Build("github.com/DataDog/datadog-firehose-nozzle")
-	fmt.Println(pathToNozzleExecutable)
-	fmt.Println("file exists", Exists(pathToNozzleExecutable))
 	Expect(err).ShouldNot(HaveOccurred())
 })
 


### PR DESCRIPTION
### What does this PR do?

Warmup cache at startup time of the nozzle, by getting a list of all the apps calling the endpoint `/v2/apps`. 
Pagination is maximum 100 result per page, but it should result in a lot less HTTP calls than currently to build the cache. Additionally, this should decrease the load on the cloud controller.
e.g. for 10000 apps, we will make a hundred API calls, per nozzle instance, every time the nozzle starts, and the cache is ready to go. Before we would have to make 1 call per app, i.e. 10000 thousand calls.

This would likely slow a bit the startup time, but now that the nozzle is more resilient to crashes, startups should not happen too often.
Then there is a background thread that will refresh the entire cache using the same mechanism at regular intervals

To do this, I also removed the local db that stored the contents of the cache for faster startup in case of nozzle crash, since it becomes useless with this new solution.

Lastly, the API has a parameter `inline-depth-relation` that allows getting the space and org data in the same API call. It is used by the `go-cfclient` so I leveraged that to reduce even further the number of API calls

### Motivation

Cache warmup is too long, causing the nozzle to not being able to keep up with the incoming metrics, and hammers the cloud controller.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?