### PR TITLE
drop and log NAN point values

### DIFF
--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -377,8 +377,8 @@ var _ = Describe("DatadogClient", func() {
 	It("parses proxy URLs correctly & chooses the correct proxy to use by scheme", func() {
 		println("proxy test")
 		proxy := &Proxy{
-			HTTP:    "http://user:password@host.com:port",
-			HTTPS:   "https://user:password@host.com:port",
+			HTTP:    "http://user:password@host.com:1234",
+			HTTPS:   "https://user:password@host.com:1234",
 			NoProxy: []string{"datadoghq.com"},
 		}
 
@@ -391,10 +391,10 @@ var _ = Describe("DatadogClient", func() {
 
 		proxyURL, err := proxyFunc(rHTTP)
 		Expect(err).To(BeNil())
-		Expect(proxyURL.String()).To(Equal("http://user:password@host.com:port"))
+		Expect(proxyURL.String()).To(Equal("http://user:password@host.com:1234"))
 		proxyURL, err = proxyFunc(rHTTPS)
 		Expect(err).To(BeNil())
-		Expect(proxyURL.String()).To(Equal("https://user:password@host.com:port"))
+		Expect(proxyURL.String()).To(Equal("https://user:password@host.com:1234"))
 
 		proxyURL, err = proxyFunc(rHTTPNoProxy)
 		Expect(err).To(BeNil())

--- a/internal/client/datadog/formatter_test.go
+++ b/internal/client/datadog/formatter_test.go
@@ -3,9 +3,10 @@ package datadog
 import (
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
 	"github.com/DataDog/datadog-firehose-nozzle/test/helper"
-
+	"github.com/cloudfoundry/gosteno"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"math"
 )
 
 var _ = Describe("Formatter", func() {
@@ -14,7 +15,7 @@ var _ = Describe("Formatter", func() {
 	)
 
 	BeforeEach(func() {
-		formatter = Formatter{}
+		formatter = Formatter{gosteno.NewLogger("test")}
 	})
 
 	It("does not return empty data", func() {
@@ -55,5 +56,23 @@ var _ = Describe("Formatter", func() {
 		result := formatter.Format("some-prefix", 1024, m)
 
 		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"metric":"bosh.healthmonitor.foo"`))
+	})
+
+	It("drops metrics that have a NAN value", func() {
+		m := make(map[metric.MetricKey]metric.MetricValue)
+		m[metric.MetricKey{Name: "bosh.healthmonitor.foo"}] = metric.MetricValue{
+			Points: []metric.Point{{
+				Value: 9,
+			},{
+				Value: math.Log(-1.0),  //creates a NAN
+			},{
+				Value: math.Log(-2.0),  //creates a NAN
+			},{
+				Value: 1.0,  //creates a NAN
+			}},
+		}
+		result := formatter.Format("some-prefix", 1024, m)
+		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"metric":"bosh.healthmonitor.foo"`))
+		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"points":[[0,9.000000],[0,1.000000]]`))
 	})
 })


### PR DESCRIPTION
The loggregator envelope can emit a NAN as the value for a Gauge metric.  When the nozzle encounters this, it currently drop an entire batch of metrics.  Instead of dropping the entire batch this will just drop the NAN data point. 


Signed-off-by: Robert Sullivan <rsullivan@pivotal.io>

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
