### PR TITLE
Append api/v1/series to api URL in code instead of hardcoding in config

### DIFF
--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -61,6 +61,36 @@ var _ = Describe("DatadogClient", func() {
 		)
 	})
 
+	Context("It parses configured URL correctly", func() {
+		It("appends api/v1/series if not present", func() {
+			// With trailing slash
+			c.apiURL = "https://app.datadoghq.com/"
+			result, err := c.seriesURL()
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal("https://app.datadoghq.com/api/v1/series?api_key=dummykey"))
+
+			// Without trailing slash
+			c.apiURL = "https://app.datadoghq.com"
+			result, err = c.seriesURL()
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal("https://app.datadoghq.com/api/v1/series?api_key=dummykey"))
+		})
+
+		It("doesn't append api/v1/series if present", func() {
+			c.apiURL = "https://app.datadoghq.com/api/v1/series"
+			result, err := c.seriesURL()
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal("https://app.datadoghq.com/api/v1/series?api_key=dummykey"))
+		})
+
+		It("keeps query and path intact", func() {
+			c.apiURL = "https://app.datadoghq.com/a/path?key=value"
+			result, err := c.seriesURL()
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal("https://app.datadoghq.com/a/path/api/v1/series?api_key=dummykey&key=value"))
+		})
+	})
+
 	Context("datadog does not respond", func() {
 		var fakeBuffer *helper.FakeBufferSink
 

--- a/internal/client/datadog/formatter_test.go
+++ b/internal/client/datadog/formatter_test.go
@@ -63,11 +63,11 @@ var _ = Describe("Formatter", func() {
 		m[metric.MetricKey{Name: "bosh.healthmonitor.foo"}] = metric.MetricValue{
 			Points: []metric.Point{{
 				Value: 9,
-			},{
-				Value: math.Log(-1.0),  //creates a NAN
-			},{
-				Value: math.Log(-2.0),  //creates a NAN
-			},{
+			}, {
+				Value: math.Log(-1.0), //creates a NAN
+			}, {
+				Value: math.Log(-2.0), //creates a NAN
+			}, {
 				Value: 1.0,
 			}},
 		}


### PR DESCRIPTION
### Motivation

Was breaking additional_endpoints functionality because the `api/v1/series` path wasn't being appended to additional urls.

Related to https://github.com/DataDog/pcf-datadog-cluster-monitoring/pull/3