### PR TITLE
Make batch sizes for Cloud Controller API requests configurable

### DIFF
--- a/config/datadog-firehose-nozzle.json
+++ b/config/datadog-firehose-nozzle.json
@@ -19,6 +19,7 @@
   "DisableAccessControl": false,
   "IdleTimeoutSeconds" : 60,
   "CloudControllerEndpoint": "string",
+  "CloudControllerAPIBatchSize": 2500,
   "AppMetrics": true,
   "NumWorkers": 1,
   "CustomTags": []

--- a/internal/client/cloudfoundry/client.go
+++ b/internal/client/cloudfoundry/client.go
@@ -17,10 +17,11 @@ import (
 )
 
 type CFClient struct {
-	ApiVersion int
-	NumWorkers int
-	client     *cfclient.Client
-	logger     *gosteno.Logger
+	ApiVersion   int
+	NumWorkers   int
+	client       *cfclient.Client
+	logger       *gosteno.Logger
+	apiBatchSize string
 }
 
 // CFApplication represents a Cloud Controller Application.
@@ -127,10 +128,11 @@ func NewClient(config *config.Config, logger *gosteno.Logger) (*CFClient, error)
 	}
 
 	cfc := CFClient{
-		ApiVersion: 0,
-		NumWorkers: config.NumWorkers,
-		client:     cfClient,
-		logger:     logger,
+		ApiVersion:   0,
+		NumWorkers:   config.NumWorkers,
+		client:       cfClient,
+		logger:       logger,
+		apiBatchSize: fmt.Sprint(config.CloudControllerAPIBatchSize),
 	}
 	return &cfc, nil
 }
@@ -298,7 +300,7 @@ func (cfc *CFClient) getV3Apps() ([]CFApplication, error) {
 
 	for page := 1; ; page++ {
 		q := url.Values{}
-		q.Set("per_page", "5000") // 5000 is the max
+		q.Set("per_page", cfc.apiBatchSize)
 		q.Set("page", strconv.Itoa(page))
 		r := cfc.client.NewRequest("GET", "/v3/apps?"+q.Encode())
 		resp, err := cfc.client.DoRequest(r)
@@ -337,7 +339,7 @@ func (cfc *CFClient) getV3Processes() ([]cfclient.Process, error) {
 	var cfprocesses []cfclient.Process
 	for page := 1; ; page++ {
 		q := url.Values{}
-		q.Set("per_page", "5000") // 5000 is the max
+		q.Set("per_page", cfc.apiBatchSize)
 		q.Set("page", strconv.Itoa(page))
 		r := cfc.client.NewRequest("GET", "/v3/processes?"+q.Encode())
 		resp, err := cfc.client.DoRequest(r)
@@ -370,7 +372,7 @@ func (cfc *CFClient) getV3Spaces() ([]v3SpaceResource, error) {
 
 	for page := 1; ; page++ {
 		q := url.Values{}
-		q.Set("per_page", "5000") // 5000 is the max
+		q.Set("per_page", cfc.apiBatchSize)
 		q.Set("page", strconv.Itoa(page))
 		r := cfc.client.NewRequest("GET", "/v3/spaces?"+q.Encode())
 		resp, err := cfc.client.DoRequest(r)
@@ -403,7 +405,7 @@ func (cfc *CFClient) getV3Orgs() ([]cfclient.Org, error) {
 
 	for page := 1; ; page++ {
 		q := url.Values{}
-		q.Set("per_page", "5000") // 5000 is the max
+		q.Set("per_page", cfc.apiBatchSize)
 		q.Set("page", strconv.Itoa(page))
 		r := cfc.client.NewRequest("GET", "/v3/organizations?"+q.Encode())
 		resp, err := cfc.client.DoRequest(r)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,42 +10,44 @@ import (
 )
 
 const (
-	defaultGrabInterval         int    = 10
-	defaultWorkers              int    = 4
-	defaultIdleTimeoutSeconds   uint32 = 60
-	defaultWorkerTimeoutSeconds uint32 = 10
+	defaultCloudControllerAPIBatchSize uint32 = 2500
+	defaultGrabInterval                int    = 10
+	defaultWorkers                     int    = 4
+	defaultIdleTimeoutSeconds          uint32 = 60
+	defaultWorkerTimeoutSeconds        uint32 = 10
 )
 
 // Config contains all the config parameters
 type Config struct {
-	UAAURL                     string
-	Client                     string
-	ClientSecret               string
-	TrafficControllerURL       string
-	FirehoseSubscriptionID     string
-	DataDogURL                 string
-	DataDogAPIKey              string
-	DataDogAdditionalEndpoints map[string][]string
-	HTTPProxyURL               string
-	HTTPSProxyURL              string
-	NoProxy                    []string
-	CloudControllerEndpoint    string
-	DataDogTimeoutSeconds      uint32
-	FlushDurationSeconds       uint32
-	FlushMaxBytes              uint32
-	InsecureSSLSkipVerify      bool
-	MetricPrefix               string
-	Deployment                 string
-	DeploymentFilter           string
-	DisableAccessControl       bool
-	IdleTimeoutSeconds         uint32
-	AppMetrics                 bool
-	NumWorkers                 int
-	NumCacheWorkers            int
-	GrabInterval               int
-	CustomTags                 []string
-	EnvironmentName            string
-	WorkerTimeoutSeconds       uint32
+	UAAURL                      string
+	Client                      string
+	ClientSecret                string
+	TrafficControllerURL        string
+	FirehoseSubscriptionID      string
+	DataDogURL                  string
+	DataDogAPIKey               string
+	DataDogAdditionalEndpoints  map[string][]string
+	HTTPProxyURL                string
+	HTTPSProxyURL               string
+	NoProxy                     []string
+	CloudControllerEndpoint     string
+	CloudControllerAPIBatchSize uint32
+	DataDogTimeoutSeconds       uint32
+	FlushDurationSeconds        uint32
+	FlushMaxBytes               uint32
+	InsecureSSLSkipVerify       bool
+	MetricPrefix                string
+	Deployment                  string
+	DeploymentFilter            string
+	DisableAccessControl        bool
+	IdleTimeoutSeconds          uint32
+	AppMetrics                  bool
+	NumWorkers                  int
+	NumCacheWorkers             int
+	GrabInterval                int
+	CustomTags                  []string
+	EnvironmentName             string
+	WorkerTimeoutSeconds        uint32
 }
 
 // Parse parses the config from the json configuration and environment variables
@@ -72,6 +74,7 @@ func Parse(configPath string) (*Config, error) {
 
 	overrideWithEnvVar("HTTP_PROXY", &config.HTTPProxyURL)
 	overrideWithEnvVar("HTTPS_PROXY", &config.HTTPSProxyURL)
+	overrideWithEnvUint32("NOZZLE_CLOUDCONTROLLERAPIBATCHSIZE", &config.CloudControllerAPIBatchSize)
 	overrideWithEnvUint32("NOZZLE_DATADOGTIMEOUTSECONDS", &config.DataDogTimeoutSeconds)
 	overrideWithEnvVar("NOZZLE_METRICPREFIX", &config.MetricPrefix)
 	overrideWithEnvVar("NOZZLE_DEPLOYMENT", &config.Deployment)
@@ -110,6 +113,12 @@ func Parse(configPath string) (*Config, error) {
 
 	if config.WorkerTimeoutSeconds == 0 {
 		config.WorkerTimeoutSeconds = defaultWorkerTimeoutSeconds
+	}
+
+	if config.CloudControllerAPIBatchSize == 0 {
+		config.CloudControllerAPIBatchSize = defaultCloudControllerAPIBatchSize
+	} else if config.CloudControllerAPIBatchSize < 100 || config.CloudControllerAPIBatchSize > 5000 {
+		return nil, fmt.Errorf("CloudControllerAPIBatchSize must be an integer >= 100 and <= 5000")
 	}
 
 	overrideWithEnvInt("NOZZLE_NUM_WORKERS", &config.NumWorkers)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,7 +74,7 @@ func Parse(configPath string) (*Config, error) {
 
 	overrideWithEnvVar("HTTP_PROXY", &config.HTTPProxyURL)
 	overrideWithEnvVar("HTTPS_PROXY", &config.HTTPSProxyURL)
-	overrideWithEnvUint32("NOZZLE_CLOUDCONTROLLERAPIBATCHSIZE", &config.CloudControllerAPIBatchSize)
+	overrideWithEnvUint32("NOZZLE_CLOUD_CONTROLLER_API_BATCH_SIZE", &config.CloudControllerAPIBatchSize)
 	overrideWithEnvUint32("NOZZLE_DATADOGTIMEOUTSECONDS", &config.DataDogTimeoutSeconds)
 	overrideWithEnvVar("NOZZLE_METRICPREFIX", &config.MetricPrefix)
 	overrideWithEnvVar("NOZZLE_DEPLOYMENT", &config.Deployment)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.NumWorkers).To(Equal(1))
 		Expect(conf.NumCacheWorkers).To(Equal(2))
 		Expect(conf.GrabInterval).To(Equal(50))
+		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(1000))
 	})
 
 	It("successfully sets default configuration values", func() {
@@ -52,6 +53,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.IdleTimeoutSeconds).To(BeEquivalentTo(60))
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(10))
 		Expect(conf.GrabInterval).To(Equal(10))
+		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(2500))
 	})
 
 	It("successfully overwrites file config values with environmental variables", func() {
@@ -77,6 +79,7 @@ var _ = Describe("NozzleConfig", func() {
 		os.Setenv("NOZZLE_NUM_WORKERS", "3")
 		os.Setenv("NOZZLE_NUM_CACHE_WORKERS", "5")
 		os.Setenv("NOZZLE_GRAB_INTERVAL", "50")
+		os.Setenv("NOZZLE_CLOUDCONTROLLERAPIBATCHSIZE", "100")
 		conf, err := Parse("testdata/test_config.json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(conf.UAAURL).To(Equal("https://uaa.walnut-env.cf-app.com"))
@@ -100,5 +103,6 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.NumWorkers).To(Equal(3))
 		Expect(conf.NumCacheWorkers).To(Equal(5))
 		Expect(conf.GrabInterval).To(Equal(50))
+		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(100))
 	})
 })

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -79,7 +79,7 @@ var _ = Describe("NozzleConfig", func() {
 		os.Setenv("NOZZLE_NUM_WORKERS", "3")
 		os.Setenv("NOZZLE_NUM_CACHE_WORKERS", "5")
 		os.Setenv("NOZZLE_GRAB_INTERVAL", "50")
-		os.Setenv("NOZZLE_CLOUDCONTROLLERAPIBATCHSIZE", "100")
+		os.Setenv("NOZZLE_CLOUD_CONTROLLER_API_BATCH_SIZE", "100")
 		conf, err := Parse("testdata/test_config.json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(conf.UAAURL).To(Equal("https://uaa.walnut-env.cf-app.com"))

--- a/internal/config/testdata/test_config.json
+++ b/internal/config/testdata/test_config.json
@@ -27,6 +27,7 @@
   "DisableAccessControl": false,
   "IdleTimeoutSeconds" : 60,
   "WorkerTimeoutSeconds" : 30,
+  "CloudControllerAPIBatchSize": 1000,
   "CloudControllerEndpoint": "string",
   "AppMetrics": true,
   "NumWorkers": 1,


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Makes it possible to configure batch size of API requests to Cloud Controller, sets the default to 2500 based on some observations of overloaded CC.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
