### PR TITLE
Log used config right before starting the nozzle

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,8 @@ const (
 
 // Config contains all the config parameters
 type Config struct {
+	// NOTE: When adding new attributes that can be considered secrets,
+	// make sure to mark them for omission when logging config in AsLogString
 	UAAURL                      string
 	Client                      string
 	ClientSecret                string
@@ -48,6 +50,29 @@ type Config struct {
 	CustomTags                  []string
 	EnvironmentName             string
 	WorkerTimeoutSeconds        uint32
+}
+
+// AsLogString returns a string representation of the config that is safe to log (no secrets)
+func (c *Config) AsLogString() (string, error) {
+	serialized, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	asMap := map[string]interface{}{}
+	err = json.Unmarshal(serialized, &asMap)
+	if err != nil {
+		return "", err
+	}
+	for _, attr := range []string{"ClientSecret", "DataDogAPIKey"} {
+		if _, ok := asMap[attr]; ok {
+			asMap[attr] = "*****"
+		}
+	}
+	finalSerialized, err := json.Marshal(asMap)
+	if err != nil {
+		return "", err
+	}
+	return string(finalSerialized), nil
 }
 
 // Parse parses the config from the json configuration and environment variables

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 
 // AsLogString returns a string representation of the config that is safe to log (no secrets)
 func (c *Config) AsLogString() (string, error) {
+	// convert the config object to map by marshalling and unmarshalling it back
 	serialized, err := json.Marshal(c)
 	if err != nil {
 		return "", err
@@ -63,11 +64,21 @@ func (c *Config) AsLogString() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	for _, attr := range []string{"ClientSecret", "DataDogAPIKey"} {
 		if _, ok := asMap[attr]; ok {
 			asMap[attr] = "*****"
 		}
 	}
+	if addKeys, ok := asMap["DataDogAdditionalEndpoints"]; ok && addKeys != nil {
+		for _, v := range addKeys.(map[string]interface{}) {
+			keyList := v.([]interface{})
+			for i := range keyList {
+				keyList[i] = "*****"
+			}
+		}
+	}
+
 	finalSerialized, err := json.Marshal(asMap)
 	if err != nil {
 		return "", err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,4 +105,24 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.GrabInterval).To(Equal(50))
 		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(100))
 	})
+
+	It("correctly serializes to log string", func() {
+		// For logs, we want this to be serialized as one long line without newlines
+		expected := `{"AppMetrics":true,"Client":"user","ClientSecret":"*****","CloudControllerAPIBatchSize":1000,`
+		expected += `"CloudControllerEndpoint":"string","CustomTags":["nozzle:foobar","env:prod","role:db"],`
+		expected += `"DataDogAPIKey":"*****","DataDogAdditionalEndpoints":{"https://app.datadoghq.com/api/v1/series":["*****","*****"],`
+		expected += `"https://app.datadoghq.com/api/v2/series":["*****"]},"DataDogTimeoutSeconds":5,`
+		expected += `"DataDogURL":"https://app.datadoghq.com/api/v1/series","Deployment":"deployment-name",`
+		expected += `"DeploymentFilter":"deployment-filter","DisableAccessControl":false,"EnvironmentName":"env_name",`
+		expected += `"FirehoseSubscriptionID":"datadog-nozzle","FlushDurationSeconds":15,"FlushMaxBytes":57671680,`
+		expected += `"GrabInterval":50,"HTTPProxyURL":"http://user:password@host.com:port",`
+		expected += `"HTTPSProxyURL":"https://user:password@host.com:port","IdleTimeoutSeconds":60,"InsecureSSLSkipVerify":true,`
+		expected += `"MetricPrefix":"datadogclient","NoProxy":[""],"NumCacheWorkers":2,"NumWorkers":1,`
+		expected += `"TrafficControllerURL":"wss://doppler.walnut.cf-app.com:4443","UAAURL":"https://uaa.walnut.cf-app.com","WorkerTimeoutSeconds":30}`
+		conf, err := Parse("testdata/test_config.json")
+		Expect(err).ToNot(HaveOccurred())
+		result, err := conf.AsLogString()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(expected))
+	})
 })

--- a/main.go
+++ b/main.go
@@ -34,6 +34,12 @@ func main() {
 	if config.FlushMaxBytes < flushMinBytes {
 		log.Fatalf("Config FlushMaxBytes is too low (%d): must be at least %d", config.FlushMaxBytes, flushMinBytes)
 	}
+	logString, err := config.AsLogString()
+	if err != nil {
+		log.Warnf("Failed to serialize config for logging: %s", err.Error())
+	} else {
+		log.Infof("Running nozzle with following config: %s", logString)
+	}
 	// Initialize UAATokenFetcher
 	tokenFetcher := uaatokenfetcher.New(
 		config.UAAURL,


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Logs the used config right before instantiating uaa token fetcher and the nozzle itself.

### Motivation

There are several things that go into constructing config (config file, defaults and environment variables). We want users to be able to see in logs whether the desired settings are really used.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
