### PR TITLE
Implement extraction of org memory quota metrics

### DIFF
--- a/config/datadog-firehose-nozzle.json
+++ b/config/datadog-firehose-nozzle.json
@@ -22,5 +22,6 @@
   "CloudControllerAPIBatchSize": 500,
   "AppMetrics": true,
   "NumWorkers": 1,
-  "CustomTags": []
+  "CustomTags": [],
+  "OrgDataQuerySeconds": 600
 }

--- a/config/datadog-firehose-nozzle.json
+++ b/config/datadog-firehose-nozzle.json
@@ -23,5 +23,5 @@
   "AppMetrics": true,
   "NumWorkers": 1,
   "CustomTags": [],
-  "OrgDataQuerySeconds": 600
+  "OrgDataCollectionInterval": 600
 }

--- a/internal/client/cloudfoundry/client.go
+++ b/internal/client/cloudfoundry/client.go
@@ -518,7 +518,7 @@ func (cfc *CFClient) getV2ApplicationsByPage(page int) ([]CFApplication, int, er
 func (cfc *CFClient) GetV2Orgs() ([]cfclient.Org, error) {
 	// NOTE: this is used by the OrgCollector
 	query := url.Values{}
-	query.Set("results-per-page", "1")
+	query.Set("results-per-page", "100")
 
 	allOrgs, err := cfc.client.ListOrgsByQuery(query)
 	if err != nil {

--- a/internal/client/cloudfoundry/client.go
+++ b/internal/client/cloudfoundry/client.go
@@ -515,6 +515,48 @@ func (cfc *CFClient) getV2ApplicationsByPage(page int) ([]CFApplication, int, er
 	return results, appResp.Pages, nil
 }
 
+func (cfc *CFClient) GetV2Orgs() ([]cfclient.Org, error) {
+	// NOTE: this is used by the OrgCollector
+	var allOrgs []cfclient.Org
+	query := url.Values{}
+	query.Set("results-per-page", "100")
+
+	for p := 1; ; p++{
+		query.Set("page", strconv.Itoa(p))
+		moreOrgs, err := cfc.client.ListOrgsByQuery(query)
+		if err != nil {
+			return nil, err
+		}
+		allOrgs = append(allOrgs, moreOrgs...)
+		if len(moreOrgs) < 100 {
+			break
+		}
+	}
+
+	return allOrgs, nil
+}
+
+func (cfc *CFClient) GetV2OrgQuotas() ([]cfclient.OrgQuota, error) {
+	// NOTE: this is used by the OrgCollector
+	var allQuotas []cfclient.OrgQuota
+	query := url.Values{}
+	query.Set("results-per-page", "100")
+
+	for p := 1; ; p++{
+		query.Set("page", strconv.Itoa(p))
+		moreQuotas, err := cfc.client.ListOrgQuotasByQuery(query)
+		if err != nil {
+			return nil, err
+		}
+		allQuotas = append(allQuotas, moreQuotas...)
+		if len(moreQuotas) < 100 {
+			break
+		}
+	}
+
+	return allQuotas, nil
+}
+
 func (a *CFApplication) setV2AppData(data cfclient.App) {
 	a.GUID = data.Guid
 	a.Name = data.Name

--- a/internal/client/cloudfoundry/client.go
+++ b/internal/client/cloudfoundry/client.go
@@ -516,7 +516,6 @@ func (cfc *CFClient) getV2ApplicationsByPage(page int) ([]CFApplication, int, er
 }
 
 func (cfc *CFClient) GetV2Orgs() ([]cfclient.Org, error) {
-	// NOTE: this is used by the OrgCollector
 	query := url.Values{}
 	query.Set("results-per-page", "100")
 
@@ -529,7 +528,6 @@ func (cfc *CFClient) GetV2Orgs() ([]cfclient.Org, error) {
 }
 
 func (cfc *CFClient) GetV2OrgQuotas() ([]cfclient.OrgQuota, error) {
-	// NOTE: this is used by the OrgCollector
 	query := url.Values{}
 	query.Set("results-per-page", "100")
 

--- a/internal/client/cloudfoundry/client.go
+++ b/internal/client/cloudfoundry/client.go
@@ -517,20 +517,12 @@ func (cfc *CFClient) getV2ApplicationsByPage(page int) ([]CFApplication, int, er
 
 func (cfc *CFClient) GetV2Orgs() ([]cfclient.Org, error) {
 	// NOTE: this is used by the OrgCollector
-	var allOrgs []cfclient.Org
 	query := url.Values{}
-	query.Set("results-per-page", "100")
+	query.Set("results-per-page", "1")
 
-	for p := 1; ; p++{
-		query.Set("page", strconv.Itoa(p))
-		moreOrgs, err := cfc.client.ListOrgsByQuery(query)
-		if err != nil {
-			return nil, err
-		}
-		allOrgs = append(allOrgs, moreOrgs...)
-		if len(moreOrgs) < 100 {
-			break
-		}
+	allOrgs, err := cfc.client.ListOrgsByQuery(query)
+	if err != nil {
+		return nil, err
 	}
 
 	return allOrgs, nil
@@ -538,20 +530,12 @@ func (cfc *CFClient) GetV2Orgs() ([]cfclient.Org, error) {
 
 func (cfc *CFClient) GetV2OrgQuotas() ([]cfclient.OrgQuota, error) {
 	// NOTE: this is used by the OrgCollector
-	var allQuotas []cfclient.OrgQuota
 	query := url.Values{}
 	query.Set("results-per-page", "100")
 
-	for p := 1; ; p++{
-		query.Set("page", strconv.Itoa(p))
-		moreQuotas, err := cfc.client.ListOrgQuotasByQuery(query)
-		if err != nil {
-			return nil, err
-		}
-		allQuotas = append(allQuotas, moreQuotas...)
-		if len(moreQuotas) < 100 {
-			break
-		}
+	allQuotas, err := cfc.client.ListOrgQuotasByQuery(query)
+	if err != nil {
+		return nil, err
 	}
 
 	return allQuotas, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ const (
 	defaultWorkers                     int    = 4
 	defaultIdleTimeoutSeconds          uint32 = 60
 	defaultWorkerTimeoutSeconds        uint32 = 10
-	defaultOrgDataQuerySeconds         uint32 = 600
+	defaultOrgDataCollectionInterval   uint32 = 600
 )
 
 // Config contains all the config parameters
@@ -51,7 +51,7 @@ type Config struct {
 	CustomTags                  []string
 	EnvironmentName             string
 	WorkerTimeoutSeconds        uint32
-	OrgDataQuerySeconds         uint32
+	OrgDataCollectionInterval   uint32
 }
 
 // AsLogString returns a string representation of the config that is safe to log (no secrets)
@@ -121,7 +121,7 @@ func Parse(configPath string) (*Config, error) {
 	overrideWithEnvUint32("NOZZLE_FLUSHDURATIONSECONDS", &config.FlushDurationSeconds)
 	overrideWithEnvUint32("NOZZLE_FLUSHMAXBYTES", &config.FlushMaxBytes)
 	overrideWithEnvInt("NOZZLE_GRAB_INTERVAL", &config.GrabInterval)
-	overrideWithEnvUint32("NOZZLE_ORG_DATA_QUERY_SECONDS", &config.OrgDataQuerySeconds)
+	overrideWithEnvUint32("NOZZLE_ORG_DATA_COLLECTION_INTERVAL", &config.OrgDataCollectionInterval)
 
 	overrideWithEnvBool("NOZZLE_INSECURESSLSKIPVERIFY", &config.InsecureSSLSkipVerify)
 	overrideWithEnvBool("NOZZLE_DISABLEACCESSCONTROL", &config.DisableAccessControl)
@@ -160,8 +160,8 @@ func Parse(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("CloudControllerAPIBatchSize must be an integer >= 100 and <= 5000")
 	}
 
-	if config.OrgDataQuerySeconds == 0 {
-		config.OrgDataQuerySeconds = defaultOrgDataQuerySeconds
+	if config.OrgDataCollectionInterval == 0 {
+		config.OrgDataCollectionInterval = defaultOrgDataCollectionInterval
 	}
 
 	overrideWithEnvInt("NOZZLE_NUM_WORKERS", &config.NumWorkers)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ const (
 	defaultWorkers                     int    = 4
 	defaultIdleTimeoutSeconds          uint32 = 60
 	defaultWorkerTimeoutSeconds        uint32 = 10
+	defaultOrgDataQuerySeconds         uint32 = 120
 )
 
 // Config contains all the config parameters
@@ -50,6 +51,7 @@ type Config struct {
 	CustomTags                  []string
 	EnvironmentName             string
 	WorkerTimeoutSeconds        uint32
+	OrgDataQuerySeconds         uint32
 }
 
 // AsLogString returns a string representation of the config that is safe to log (no secrets)
@@ -119,6 +121,7 @@ func Parse(configPath string) (*Config, error) {
 	overrideWithEnvUint32("NOZZLE_FLUSHDURATIONSECONDS", &config.FlushDurationSeconds)
 	overrideWithEnvUint32("NOZZLE_FLUSHMAXBYTES", &config.FlushMaxBytes)
 	overrideWithEnvInt("NOZZLE_GRAB_INTERVAL", &config.GrabInterval)
+	overrideWithEnvUint32("NOZZLE_ORG_DATA_QUERY_SECONDS", &config.OrgDataQuerySeconds)
 
 	overrideWithEnvBool("NOZZLE_INSECURESSLSKIPVERIFY", &config.InsecureSSLSkipVerify)
 	overrideWithEnvBool("NOZZLE_DISABLEACCESSCONTROL", &config.DisableAccessControl)
@@ -155,6 +158,10 @@ func Parse(configPath string) (*Config, error) {
 		config.CloudControllerAPIBatchSize = defaultCloudControllerAPIBatchSize
 	} else if config.CloudControllerAPIBatchSize < 100 || config.CloudControllerAPIBatchSize > 5000 {
 		return nil, fmt.Errorf("CloudControllerAPIBatchSize must be an integer >= 100 and <= 5000")
+	}
+
+	if config.OrgDataQuerySeconds == 0 {
+		config.OrgDataQuerySeconds = defaultOrgDataQuerySeconds
 	}
 
 	overrideWithEnvInt("NOZZLE_NUM_WORKERS", &config.NumWorkers)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ const (
 	defaultWorkers                     int    = 4
 	defaultIdleTimeoutSeconds          uint32 = 60
 	defaultWorkerTimeoutSeconds        uint32 = 10
-	defaultOrgDataQuerySeconds         uint32 = 120
+	defaultOrgDataQuerySeconds         uint32 = 600
 )
 
 // Config contains all the config parameters

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,7 +122,8 @@ var _ = Describe("NozzleConfig", func() {
 		expected += `"GrabInterval":50,"HTTPProxyURL":"http://user:password@host.com:port",`
 		expected += `"HTTPSProxyURL":"https://user:password@host.com:port","IdleTimeoutSeconds":60,"InsecureSSLSkipVerify":true,`
 		expected += `"MetricPrefix":"datadogclient","NoProxy":[""],"NumCacheWorkers":2,"NumWorkers":1,`
-		expected += `"TrafficControllerURL":"wss://doppler.walnut.cf-app.com:4443","UAAURL":"https://uaa.walnut.cf-app.com","WorkerTimeoutSeconds":30}`
+		expected += `"OrgDataQuerySeconds":100,"TrafficControllerURL":"wss://doppler.walnut.cf-app.com:4443",`
+		expected += `"UAAURL":"https://uaa.walnut.cf-app.com","WorkerTimeoutSeconds":30}`
 		conf, err := Parse("testdata/test_config.json")
 		Expect(err).ToNot(HaveOccurred())
 		result, err := conf.AsLogString()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,7 +55,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(10))
 		Expect(conf.GrabInterval).To(Equal(10))
 		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(500))
-		Expect(conf.OrgDataQuerySeconds).To(BeEquivalentTo(120))
+		Expect(conf.OrgDataQuerySeconds).To(BeEquivalentTo(600))
 	})
 
 	It("successfully overwrites file config values with environmental variables", func() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,7 +42,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.NumCacheWorkers).To(Equal(2))
 		Expect(conf.GrabInterval).To(Equal(50))
 		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(1000))
-		Expect(conf.OrgDataQuerySeconds).To(BeEquivalentTo(100))
+		Expect(conf.OrgDataCollectionInterval).To(BeEquivalentTo(100))
 	})
 
 	It("successfully sets default configuration values", func() {
@@ -55,7 +55,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(10))
 		Expect(conf.GrabInterval).To(Equal(10))
 		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(500))
-		Expect(conf.OrgDataQuerySeconds).To(BeEquivalentTo(600))
+		Expect(conf.OrgDataCollectionInterval).To(BeEquivalentTo(600))
 	})
 
 	It("successfully overwrites file config values with environmental variables", func() {
@@ -82,7 +82,7 @@ var _ = Describe("NozzleConfig", func() {
 		os.Setenv("NOZZLE_NUM_CACHE_WORKERS", "5")
 		os.Setenv("NOZZLE_GRAB_INTERVAL", "50")
 		os.Setenv("NOZZLE_CLOUD_CONTROLLER_API_BATCH_SIZE", "100")
-		os.Setenv("NOZZLE_ORG_DATA_QUERY_SECONDS", "100")
+		os.Setenv("NOZZLE_ORG_DATA_COLLECTION_INTERVAL", "100")
 		conf, err := Parse("testdata/test_config.json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(conf.UAAURL).To(Equal("https://uaa.walnut-env.cf-app.com"))
@@ -107,7 +107,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.NumCacheWorkers).To(Equal(5))
 		Expect(conf.GrabInterval).To(Equal(50))
 		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(100))
-		Expect(conf.OrgDataQuerySeconds).To(BeEquivalentTo(100))
+		Expect(conf.OrgDataCollectionInterval).To(BeEquivalentTo(100))
 	})
 
 	It("correctly serializes to log string", func() {
@@ -122,7 +122,7 @@ var _ = Describe("NozzleConfig", func() {
 		expected += `"GrabInterval":50,"HTTPProxyURL":"http://user:password@host.com:port",`
 		expected += `"HTTPSProxyURL":"https://user:password@host.com:port","IdleTimeoutSeconds":60,"InsecureSSLSkipVerify":true,`
 		expected += `"MetricPrefix":"datadogclient","NoProxy":[""],"NumCacheWorkers":2,"NumWorkers":1,`
-		expected += `"OrgDataQuerySeconds":100,"TrafficControllerURL":"wss://doppler.walnut.cf-app.com:4443",`
+		expected += `"OrgDataCollectionInterval":100,"TrafficControllerURL":"wss://doppler.walnut.cf-app.com:4443",`
 		expected += `"UAAURL":"https://uaa.walnut.cf-app.com","WorkerTimeoutSeconds":30}`
 		conf, err := Parse("testdata/test_config.json")
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.NumCacheWorkers).To(Equal(2))
 		Expect(conf.GrabInterval).To(Equal(50))
 		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(1000))
+		Expect(conf.OrgDataQuerySeconds).To(BeEquivalentTo(100))
 	})
 
 	It("successfully sets default configuration values", func() {
@@ -54,6 +55,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(10))
 		Expect(conf.GrabInterval).To(Equal(10))
 		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(500))
+		Expect(conf.OrgDataQuerySeconds).To(BeEquivalentTo(120))
 	})
 
 	It("successfully overwrites file config values with environmental variables", func() {
@@ -80,6 +82,7 @@ var _ = Describe("NozzleConfig", func() {
 		os.Setenv("NOZZLE_NUM_CACHE_WORKERS", "5")
 		os.Setenv("NOZZLE_GRAB_INTERVAL", "50")
 		os.Setenv("NOZZLE_CLOUD_CONTROLLER_API_BATCH_SIZE", "100")
+		os.Setenv("NOZZLE_ORG_DATA_QUERY_SECONDS", "100")
 		conf, err := Parse("testdata/test_config.json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(conf.UAAURL).To(Equal("https://uaa.walnut-env.cf-app.com"))
@@ -104,6 +107,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.NumCacheWorkers).To(Equal(5))
 		Expect(conf.GrabInterval).To(Equal(50))
 		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(100))
+		Expect(conf.OrgDataQuerySeconds).To(BeEquivalentTo(100))
 	})
 
 	It("correctly serializes to log string", func() {

--- a/internal/config/testdata/test_config.json
+++ b/internal/config/testdata/test_config.json
@@ -36,5 +36,6 @@
   "NoProxy": [ "*.aventail.com", "home.com", ".seanet.com" ],
   "EnvironmentName": "env_name",
   "DBPath": "/var/vcap/nozzle.db",
-  "GrabInterval": 50
+  "GrabInterval": 50,
+  "OrgDataQuerySeconds": 100
 }

--- a/internal/config/testdata/test_config.json
+++ b/internal/config/testdata/test_config.json
@@ -37,5 +37,5 @@
   "EnvironmentName": "env_name",
   "DBPath": "/var/vcap/nozzle.db",
   "GrabInterval": 50,
-  "OrgDataQuerySeconds": 100
+  "OrgDataCollectionInterval": 100
 }

--- a/internal/nozzle/nozzle_test.go
+++ b/internal/nozzle/nozzle_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 		It("runs orgCollector to obtain org metrics", func() {
 			// need to use function to always return the current UsedEndpoints, since it's appended to
 			// and thus the address of the slice changes
-			Eventually(func () []string {return fakeCCAPI.UsedEndpoints}, 10, 1).Should(ContainElement("/v2/quota_definitions"))
+			Eventually(fakeCCAPI.GetUsedEndpoints, 10, 1).Should(ContainElement("/v2/quota_definitions"))
 		})
 
 		It("adds internal metrics and generates aggregate messages when idle", func() {

--- a/internal/nozzle/nozzle_test.go
+++ b/internal/nozzle/nozzle_test.go
@@ -61,23 +61,23 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			fakeDatadogAPI.Start()
 
 			configuration = &config.Config{
-				UAAURL:               fakeUAA.URL(),
-				FlushDurationSeconds: 2,
-				FlushMaxBytes:        10240,
-				DataDogURL:           fakeDatadogAPI.URL(),
-				CloudControllerEndpoint: fakeCCAPI.URL(),
-				Client:        			"bearer",
-				ClientSecret:      	   "123456789",
-				InsecureSSLSkipVerify: true,
-				DataDogAPIKey:        "1234567890",
-				TrafficControllerURL: strings.Replace(fakeFirehose.URL(), "http:", "ws:", 1),
-				DisableAccessControl: false,
-				WorkerTimeoutSeconds: 10,
-				MetricPrefix:         "datadog.nozzle.",
-				Deployment:           "nozzle-deployment",
-				AppMetrics:           false,
-				NumWorkers:           1,
-				OrgDataQuerySeconds:  5,
+				UAAURL:                    fakeUAA.URL(),
+				FlushDurationSeconds:      2,
+				FlushMaxBytes:             10240,
+				DataDogURL:                fakeDatadogAPI.URL(),
+				CloudControllerEndpoint:   fakeCCAPI.URL(),
+				Client:                    "bearer",
+				ClientSecret:              "123456789",
+				InsecureSSLSkipVerify:     true,
+				DataDogAPIKey:             "1234567890",
+				TrafficControllerURL:      strings.Replace(fakeFirehose.URL(), "http:", "ws:", 1),
+				DisableAccessControl:      false,
+				WorkerTimeoutSeconds:      10,
+				MetricPrefix:              "datadog.nozzle.",
+				Deployment:                "nozzle-deployment",
+				AppMetrics:                false,
+				NumWorkers:                1,
+				OrgDataCollectionInterval: 5,
 			}
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
@@ -352,16 +352,16 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			fakeCCAPI.Start()
 
 			configuration = &config.Config{
-				FlushDurationSeconds: 1,
-				FlushMaxBytes:        10240,
-				DataDogURL:           fakeDatadogAPI.URL(),
-				DataDogAPIKey:        "1234567890",
-				CloudControllerEndpoint: fakeCCAPI.URL(),
-				TrafficControllerURL: strings.Replace(fakeFirehose.URL(), "http:", "ws:", 1),
-				DisableAccessControl: true,
-				NumWorkers:           1,
-				AppMetrics:           false,
-				OrgDataQuerySeconds:  120,
+				FlushDurationSeconds:      1,
+				FlushMaxBytes:             10240,
+				DataDogURL:                fakeDatadogAPI.URL(),
+				DataDogAPIKey:             "1234567890",
+				CloudControllerEndpoint:   fakeCCAPI.URL(),
+				TrafficControllerURL:      strings.Replace(fakeFirehose.URL(), "http:", "ws:", 1),
+				DisableAccessControl:      true,
+				NumWorkers:                1,
+				AppMetrics:                false,
+				OrgDataCollectionInterval: 120,
 			}
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
@@ -405,20 +405,20 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			fakeCCAPI.Start()
 
 			configuration = &config.Config{
-				UAAURL:               fakeUAA.URL(),
-				FlushDurationSeconds: 2,
-				FlushMaxBytes:        10240,
-				DataDogURL:           fakeDatadogAPI.URL(),
-				DataDogAPIKey:        "1234567890",
-				CloudControllerEndpoint: fakeCCAPI.URL(),
-				TrafficControllerURL: strings.Replace(fakeFirehose.URL(), "http:", "ws:", 1),
-				DisableAccessControl: false,
-				WorkerTimeoutSeconds: 1,
-				MetricPrefix:         "datadog.nozzle.",
-				Deployment:           "nozzle-deployment",
-				AppMetrics:           false,
-				NumWorkers:           1,
-				OrgDataQuerySeconds:  120,
+				UAAURL:                    fakeUAA.URL(),
+				FlushDurationSeconds:      2,
+				FlushMaxBytes:             10240,
+				DataDogURL:                fakeDatadogAPI.URL(),
+				DataDogAPIKey:             "1234567890",
+				CloudControllerEndpoint:   fakeCCAPI.URL(),
+				TrafficControllerURL:      strings.Replace(fakeFirehose.URL(), "http:", "ws:", 1),
+				DisableAccessControl:      false,
+				WorkerTimeoutSeconds:      1,
+				MetricPrefix:              "datadog.nozzle.",
+				Deployment:                "nozzle-deployment",
+				AppMetrics:                false,
+				NumWorkers:                1,
+				OrgDataCollectionInterval: 120,
 			}
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)
@@ -455,20 +455,20 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			fakeDatadogAPI.Start()
 
 			configuration = &config.Config{
-				UAAURL:               fakeUAA.URL(),
-				FlushDurationSeconds: 2,
-				FlushMaxBytes:        10240,
-				DataDogURL:           fakeDatadogAPI.URL(),
-				DataDogAPIKey:        "1234567890",
-				CloudControllerEndpoint: "",
-				TrafficControllerURL: strings.Replace(fakeFirehose.URL(), "http:", "ws:", 1),
-				DisableAccessControl: false,
-				WorkerTimeoutSeconds: 1,
-				MetricPrefix:         "datadog.nozzle.",
-				Deployment:           "nozzle-deployment",
-				AppMetrics:           false,
-				NumWorkers:           1,
-				OrgDataQuerySeconds:  120,
+				UAAURL:                    fakeUAA.URL(),
+				FlushDurationSeconds:      2,
+				FlushMaxBytes:             10240,
+				DataDogURL:                fakeDatadogAPI.URL(),
+				DataDogAPIKey:             "1234567890",
+				CloudControllerEndpoint:   "",
+				TrafficControllerURL:      strings.Replace(fakeFirehose.URL(), "http:", "ws:", 1),
+				DisableAccessControl:      false,
+				WorkerTimeoutSeconds:      1,
+				MetricPrefix:              "datadog.nozzle.",
+				Deployment:                "nozzle-deployment",
+				AppMetrics:                false,
+				NumWorkers:                1,
+				OrgDataCollectionInterval: 120,
 			}
 
 			tokenFetcher := uaatokenfetcher.New(fakeUAA.URL(), "un", "pwd", true, log)

--- a/internal/nozzle/nozzle_test.go
+++ b/internal/nozzle/nozzle_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			var payload datadog.Payload
 			err := json.Unmarshal(helper.Decompress(contents), &payload)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(payload.Series).To(HaveLen(23)) // +3 is because of the internal metrics
+			Expect(payload.Series).To(HaveLen(25)) // +3 is because of the internal metrics, +2 because of org metrics
 		}, 2)
 
 		It("gets a valid authentication token", func() {
@@ -154,9 +154,9 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			var payload datadog.Payload
 			err := json.Unmarshal(helper.Decompress(contents), &payload)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(payload.Series).To(HaveLen(23))
+			Expect(payload.Series).To(HaveLen(25))
 
-			validateMetrics(payload, 10, 0)
+			validateMetrics(payload, 11, 0) // +1 for total messages because of Org Quota
 
 			// Wait a bit more for the new tick. We should receive only internal metrics
 			Eventually(fakeDatadogAPI.ReceivedContents, 15*time.Second, time.Second).Should(Receive(&contents))
@@ -164,7 +164,7 @@ var _ = Describe("Datadog Firehose Nozzle", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(payload.Series).To(HaveLen(3)) // only internal metrics
 
-			validateMetrics(payload, 10, 23)
+			validateMetrics(payload, 11, 25)
 		}, 3)
 
 		It("reports a slow-consumer error when the server disconnects abnormally", func() {

--- a/internal/orgcollector/orgcollector.go
+++ b/internal/orgcollector/orgcollector.go
@@ -122,7 +122,6 @@ func (o *OrgCollector) pushMetrics() {
 		}
 		value := metric.MetricValue{
 			Tags: tags,
-			// TODO: what host do we want to provide?
 			Points: []metric.Point{
 				metric.Point{
 					Timestamp: time.Now().Unix(),

--- a/internal/orgcollector/orgcollector.go
+++ b/internal/orgcollector/orgcollector.go
@@ -39,7 +39,7 @@ func NewOrgCollector(
 		log:              log,
 		processedMetrics: processedMetrics,
 		customTags:       customTags,
-		queryInterval:    config.OrgDataQuerySeconds,
+		queryInterval:    config.OrgDataCollectionInterval,
 		stopper:          make(chan bool),
 	}, nil
 }

--- a/internal/orgcollector/orgcollector.go
+++ b/internal/orgcollector/orgcollector.go
@@ -95,7 +95,7 @@ func (o *OrgCollector) pushMetrics() {
 	wg.Wait()
 	close(errors)
 
-	// Go through the channel, print all errors and return one of them if there are any
+	// Go through the channel and print all errors
 	for err := range errors {
 		o.log.Error(err.Error())
 	}

--- a/internal/orgcollector/orgcollector.go
+++ b/internal/orgcollector/orgcollector.go
@@ -54,6 +54,9 @@ func (o *OrgCollector) Stop() {
 
 func (o *OrgCollector) run() {
 	ticker := time.NewTicker(time.Duration(o.queryInterval) * time.Second)
+	// If the nozzle is restarted in the middle of o.queryInterval, there'd
+	// be a quite large gap in the data submitted
+	go o.pushMetrics()
 	for {
 		select {
 		case <-ticker.C:

--- a/internal/orgcollector/orgcollector.go
+++ b/internal/orgcollector/orgcollector.go
@@ -1,0 +1,147 @@
+// NOTE: whenever the CC API V3 exposes the quota information for us,
+// we should just store everything in the app cache and get it from there
+package orgcollector
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-firehose-nozzle/internal/client/cloudfoundry"
+	"github.com/DataDog/datadog-firehose-nozzle/internal/config"
+	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
+	"github.com/DataDog/datadog-firehose-nozzle/internal/util"
+
+	"github.com/cloudfoundry-community/go-cfclient"
+	"github.com/cloudfoundry/gosteno"
+)
+
+type OrgCollector struct {
+	cfClient              *cloudfoundry.CFClient
+	log                   *gosteno.Logger
+	processedMetrics      chan<- []metric.MetricPackage
+	customTags            []string
+	queryInterval		  uint32
+	stopper               chan bool
+}
+
+func NewOrgCollector(
+	config *config.Config,
+	processedMetrics chan<- []metric.MetricPackage,
+	log *gosteno.Logger,
+	customTags []string) (*OrgCollector, error) {
+	cfClient, err := cloudfoundry.NewClient(config, log)
+	if err != nil {
+		return nil, err
+	}
+	return &OrgCollector{
+		cfClient:         cfClient,
+		log:              log,
+		processedMetrics: processedMetrics,
+		customTags:       customTags,
+		queryInterval:    config.OrgDataQuerySeconds,
+		stopper:          make(chan bool),
+	}, nil
+}
+
+func (o *OrgCollector) Start() {
+	go o.run()
+}
+
+func (o *OrgCollector) Stop() {
+	o.stopper <- true
+}
+
+func (o *OrgCollector) run() {
+	ticker := time.NewTicker(time.Duration(o.queryInterval) * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			go o.pushMetrics()
+		case <-o.stopper:
+			return
+		}
+	}
+}
+
+func (o *OrgCollector) pushMetrics() {
+	var wg sync.WaitGroup
+	errors := make(chan error, 10)
+	// Fetch orgs
+	wg.Add(1)
+	var allOrgs []cfclient.Org
+	go func() {
+		defer wg.Done()
+		var err error
+		allOrgs, err = o.cfClient.GetV2Orgs()
+		if err != nil {
+			errors <- err
+		}
+	}()
+
+	// Fetch quotas
+	wg.Add(1)
+	var allQuotas []cfclient.OrgQuota
+	go func() {
+		defer wg.Done()
+		var err error
+		allQuotas, err = o.cfClient.GetV2OrgQuotas()
+		if err != nil {
+			errors <- err
+		}
+	}()
+
+	wg.Wait()
+	close(errors)
+
+	// Go through the channel, print all errors and return one of them if there are any
+	for err := range errors {
+		o.log.Error(err.Error())
+	}
+
+	// Create a map of {OrgQuota.Guid: OrgQuota} to make access fast
+	quotaGuidsToObjects := map[string]cfclient.OrgQuota{}
+	for _, q := range allQuotas {
+		quotaGuidsToObjects[q.Guid] = q
+	}
+
+	metricsPackages := []metric.MetricPackage{}
+	for _, org := range allOrgs {
+		q, ok := quotaGuidsToObjects[org.QuotaDefinitionGuid]
+		if !ok {
+			o.log.Warnf("failed to get quota for org %s", org.Guid)
+			continue
+		}
+		tags := []string{}
+		tags = append(tags, o.customTags...)
+		tags = append(tags, o.getTagsFromOrg(org)...)
+		key := metric.MetricKey{
+			Name:     "org.memory.quota",
+			TagsHash: util.HashTags(tags),
+		}
+		value := metric.MetricValue{
+			Tags: tags,
+			// TODO: what host do we want to provide?
+			Points: []metric.Point{
+				metric.Point{
+					Timestamp: time.Now().Unix(),
+					Value:     float64(q.MemoryLimit),
+				},
+			},
+		}
+		metricsPackages = append(metricsPackages, metric.MetricPackage{
+			MetricKey: &key,
+			MetricValue: &value,
+		})
+	}
+	o.processedMetrics <- metricsPackages
+}
+
+func (o *OrgCollector) getTagsFromOrg(org cfclient.Org) []string {
+	tags := []string{}
+	tags = append(tags, fmt.Sprintf("guid:%s", org.Guid))
+	tags = append(tags, fmt.Sprintf("org_name:%s", org.Name))
+	tags = append(tags, fmt.Sprintf("org_id:%s", org.Guid))
+	tags = append(tags, fmt.Sprintf("status:%s", org.Status))
+	return tags
+}

--- a/internal/orgcollector/orgcollector.go
+++ b/internal/orgcollector/orgcollector.go
@@ -17,12 +17,12 @@ import (
 )
 
 type OrgCollector struct {
-	cfClient              *cloudfoundry.CFClient
-	log                   *gosteno.Logger
-	processedMetrics      chan<- []metric.MetricPackage
-	customTags            []string
-	queryInterval		  uint32
-	stopper               chan bool
+	cfClient         *cloudfoundry.CFClient
+	log              *gosteno.Logger
+	processedMetrics chan<- []metric.MetricPackage
+	customTags       []string
+	queryInterval    uint32
+	stopper          chan bool
 }
 
 func NewOrgCollector(
@@ -65,6 +65,7 @@ func (o *OrgCollector) run() {
 }
 
 func (o *OrgCollector) pushMetrics() {
+	o.log.Info("Collecting org quotas ...")
 	var wg sync.WaitGroup
 	errors := make(chan error, 10)
 	// Fetch orgs
@@ -130,10 +131,11 @@ func (o *OrgCollector) pushMetrics() {
 			},
 		}
 		metricsPackages = append(metricsPackages, metric.MetricPackage{
-			MetricKey: &key,
+			MetricKey:   &key,
 			MetricValue: &value,
 		})
 	}
+	o.log.Debugf("Collected org quotas for %d orgs", len(metricsPackages))
 	o.processedMetrics <- metricsPackages
 }
 

--- a/internal/orgcollector/orgcollector_suite_test.go
+++ b/internal/orgcollector/orgcollector_suite_test.go
@@ -1,0 +1,13 @@
+package orgcollector
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestOrgCollector(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OrgCollector Suite")
+}

--- a/internal/orgcollector/orgcollector_test.go
+++ b/internal/orgcollector/orgcollector_test.go
@@ -1,0 +1,83 @@
+package orgcollector
+
+import (
+	. "github.com/DataDog/datadog-firehose-nozzle/test/helper"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/gosteno"
+	//"github.com/cloudfoundry-community/go-cfclient"
+
+	"github.com/DataDog/datadog-firehose-nozzle/internal/config"
+	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
+)
+
+var _ = Describe("OrgCollector", func() {
+	var (
+		log                    *gosteno.Logger
+		fakeCloudControllerAPI *FakeCloudControllerAPI
+		ccAPIURL               string
+		fakeOrgCollector       *OrgCollector
+		pm                     chan []metric.MetricPackage
+		customTags             []string
+	)
+
+	BeforeEach(func() {
+		log = gosteno.NewLogger("cloudfoundry client test")
+		fakeCloudControllerAPI = NewFakeCloudControllerAPI("bearer", "123456789")
+		fakeCloudControllerAPI.Start()
+
+		ccAPIURL = fakeCloudControllerAPI.URL()
+		cfg := config.Config{
+			CloudControllerEndpoint:	ccAPIURL,
+			Client:          			"bearer",
+			ClientSecret:      			"123456789",
+			InsecureSSLSkipVerify: 		true,
+			NumWorkers:					0,
+		}
+		pm = make(chan []metric.MetricPackage, 1)
+		customTags = []string{"foo:bar"}
+
+		var err error
+		fakeOrgCollector, err = NewOrgCollector(
+			&cfg,
+			pm,
+			log,
+			customTags,
+		)
+		Expect(err).To(BeNil())
+	}, 0)
+
+	It("pushes correct metrics", func() {
+		fakeOrgCollector.pushMetrics()
+		pushed := <-pm
+
+		k1 := pushed[0].MetricKey
+		v1 := pushed[0].MetricValue
+		Expect(k1.Name).To(Equal("org.memory.quota"))
+		Expect(v1.Tags).To(Equal([]string{
+			"foo:bar",
+			"guid:671557cf-edcd-49df-9863-ee14513d13c7",
+			"org_id:671557cf-edcd-49df-9863-ee14513d13c7",
+			"org_name:system",
+			"status:active",
+		}))
+		Expect(v1.Points).To(HaveLen(1))
+		Expect(v1.Points[0].Timestamp).To(BeNumerically(">", 0))
+		Expect(v1.Points[0].Value).To(Equal(float64(102400)))
+
+		k2 := pushed[1].MetricKey
+		v2 := pushed[1].MetricValue
+		Expect(k2.Name).To(Equal("org.memory.quota"))
+		Expect(v2.Tags).To(Equal([]string{
+			"foo:bar",
+			"guid:8c19a50e-7974-4c67-adea-9640fae21526",
+			"org_id:8c19a50e-7974-4c67-adea-9640fae21526",
+			"org_name:datadog-application-monitoring-org",
+			"status:active",
+		}))
+		Expect(v2.Points).To(HaveLen(1))
+		Expect(v2.Points[0].Timestamp).To(BeNumerically(">", 0))
+		Expect(v2.Points[0].Value).To(Equal(float64(102400)))
+	})
+})

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"crypto/sha1"
+	"math/rand"
 	"sort"
+	"time"
 )
 
 func HashTags(tags []string) string {
@@ -15,4 +17,16 @@ func HashTags(tags []string) string {
 		hash += string(tagHash[:])
 	}
 	return hash
+}
+
+func GetTickerWithJitter(wholeIntervalSeconds uint32, jitterPct float64) (*time.Ticker, func()) {
+	wholeTick := int64(wholeIntervalSeconds) * int64(time.Second)
+	shortenedTick := int64(float64(wholeTick) * (1.0 - jitterPct))
+	jitterMax := int64(float64(wholeTick) * jitterPct)
+	ticker := time.NewTicker(time.Duration(shortenedTick))
+	jitterWait := func() {
+		jitter := rand.Int63n(jitterMax)
+		time.Sleep(time.Duration(jitter))
+	}
+	return ticker, jitterWait
 }

--- a/test/helper/fake_cloud_controller_api.go
+++ b/test/helper/fake_cloud_controller_api.go
@@ -15,6 +15,7 @@ import (
 type FakeCloudControllerAPI struct {
 	ReceivedContents chan []byte
 	ReceivedRequests chan *http.Request
+	UsedEndpoints    []string
 
 	server *httptest.Server
 	lock   sync.Mutex
@@ -42,6 +43,7 @@ func NewFakeCloudControllerAPI(tokenType string, accessToken string) *FakeCloudC
 	return &FakeCloudControllerAPI{
 		ReceivedContents: make(chan []byte, 100),
 		ReceivedRequests: make(chan *http.Request, 100),
+		UsedEndpoints:    []string{},
 		tokenType:        tokenType,
 		accessToken:      accessToken,
 		RequestTime:      0,
@@ -72,6 +74,7 @@ func (f *FakeCloudControllerAPI) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 
 	f.ReceivedContents <- contents
 	f.ReceivedRequests <- r
+	f.UsedEndpoints = append(f.UsedEndpoints, r.URL.Path)
 
 	time.Sleep(f.RequestTime * time.Millisecond)
 	f.writeResponse(rw, r)
@@ -2823,6 +2826,118 @@ func (f *FakeCloudControllerAPI) writeResponse(rw http.ResponseWriter, r *http.R
 					]
 				}`)))
 		}
+	case "/v2/quota_definitions":
+		rw.Write([]byte(fmt.Sprintf(`{
+			"total_results": 2,
+			"total_pages": 1,
+			"prev_url": null,
+			"next_url": null,
+			"resources": [
+			   {
+				  "metadata": {
+					 "guid": "1345a873-ead6-4ae2-9d7d-e270c1a05c82",
+					 "url": "/v2/quota_definitions/1345a873-ead6-4ae2-9d7d-e270c1a05c82",
+					 "created_at": "2019-05-17T13:06:27Z",
+					 "updated_at": "2019-05-17T13:06:27Z"
+				  },
+				  "entity": {
+					 "name": "default",
+					 "non_basic_services_allowed": true,
+					 "total_services": 100,
+					 "total_routes": 1000,
+					 "total_private_domains": -1,
+					 "memory_limit": 10240,
+					 "trial_db_allowed": false,
+					 "instance_memory_limit": -1,
+					 "app_instance_limit": -1,
+					 "app_task_limit": -1,
+					 "total_service_keys": -1,
+					 "total_reserved_route_ports": 0
+				  }
+			   },
+			   {
+				  "metadata": {
+					 "guid": "1cf98856-aba8-49a8-8b21-d82a25898c4e",
+					 "url": "/v2/quota_definitions/1cf98856-aba8-49a8-8b21-d82a25898c4e",
+					 "created_at": "2019-05-17T13:06:27Z",
+					 "updated_at": "2019-05-17T13:06:27Z"
+				  },
+				  "entity": {
+					 "name": "runaway",
+					 "non_basic_services_allowed": true,
+					 "total_services": -1,
+					 "total_routes": 1000,
+					 "total_private_domains": -1,
+					 "memory_limit": 102400,
+					 "trial_db_allowed": false,
+					 "instance_memory_limit": -1,
+					 "app_instance_limit": -1,
+					 "app_task_limit": -1,
+					 "total_service_keys": -1,
+					 "total_reserved_route_ports": 0
+				  }
+			   }
+			]
+		}`)))
+	case "/v2/organizations":
+		rw.Write([]byte(fmt.Sprintf(`{
+			"total_results": 2,
+			"total_pages": 1,
+			"prev_url": null,
+			"next_url": null,
+			"resources": [
+				{
+					"metadata": {
+						"guid": "671557cf-edcd-49df-9863-ee14513d13c7",
+						"url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7",
+						"created_at": "2019-05-17T13:06:27Z",
+						"updated_at": "2019-10-04T11:10:22Z"
+					},
+					"entity": {
+						"name": "system",
+						"billing_enabled": false,
+						"quota_definition_guid": "1cf98856-aba8-49a8-8b21-d82a25898c4e",
+						"status": "active",
+						"default_isolation_segment_guid": null,
+						"quota_definition_url": "/v2/quota_definitions/1cf98856-aba8-49a8-8b21-d82a25898c4e",
+						"spaces_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/spaces",
+						"domains_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/domains",
+						"private_domains_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/private_domains",
+						"users_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/users",
+						"managers_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/managers",
+						"billing_managers_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/billing_managers",
+						"auditors_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/auditors",
+						"app_events_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/app_events",
+						"space_quota_definitions_url": "/v2/organizations/671557cf-edcd-49df-9863-ee14513d13c7/space_quota_definitions"
+					}
+				},
+				{
+					"metadata": {
+						"guid": "8c19a50e-7974-4c67-adea-9640fae21526",
+						"url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526",
+						"created_at": "2019-05-21T09:42:45Z",
+						"updated_at": "2019-05-21T09:42:45Z"
+					},
+					"entity": {
+						"name": "datadog-application-monitoring-org",
+						"billing_enabled": false,
+						"quota_definition_guid": "1cf98856-aba8-49a8-8b21-d82a25898c4e",
+						"status": "active",
+						"default_isolation_segment_guid": null,
+						"quota_definition_url": "/v2/quota_definitions/1cf98856-aba8-49a8-8b21-d82a25898c4e",
+						"spaces_url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526/spaces",
+						"domains_url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526/domains",
+						"private_domains_url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526/private_domains",
+						"users_url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526/users",
+						"managers_url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526/managers",
+						"billing_managers_url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526/billing_managers",
+						"auditors_url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526/auditors",
+						"app_events_url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526/app_events",
+						"space_quota_definitions_url": "/v2/organizations/8c19a50e-7974-4c67-adea-9640fae21526/space_quota_definitions"
+					}
+				}
+			]
+			}`)))
 	case "/v3/organizations":
 		switch r.URL.Query().Get("page") {
 		case "", "1":

--- a/test/helper/fake_cloud_controller_api.go
+++ b/test/helper/fake_cloud_controller_api.go
@@ -15,7 +15,7 @@ import (
 type FakeCloudControllerAPI struct {
 	ReceivedContents chan []byte
 	ReceivedRequests chan *http.Request
-	UsedEndpoints    []string
+	usedEndpoints    []string
 
 	server *httptest.Server
 	lock   sync.Mutex
@@ -43,7 +43,7 @@ func NewFakeCloudControllerAPI(tokenType string, accessToken string) *FakeCloudC
 	return &FakeCloudControllerAPI{
 		ReceivedContents: make(chan []byte, 100),
 		ReceivedRequests: make(chan *http.Request, 100),
-		UsedEndpoints:    []string{},
+		usedEndpoints:    []string{},
 		tokenType:        tokenType,
 		accessToken:      accessToken,
 		RequestTime:      0,
@@ -75,7 +75,7 @@ func (f *FakeCloudControllerAPI) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 	f.ReceivedContents <- contents
 	f.ReceivedRequests <- r
 	f.lock.Lock()
-	f.UsedEndpoints = append(f.UsedEndpoints, r.URL.Path)
+	f.usedEndpoints = append(f.usedEndpoints, r.URL.Path)
 	f.lock.Unlock()
 
 	time.Sleep(f.RequestTime * time.Millisecond)
@@ -84,6 +84,12 @@ func (f *FakeCloudControllerAPI) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 	f.lock.Lock()
 	f.requested = true
 	f.lock.Unlock()
+}
+
+func (f *FakeCloudControllerAPI) GetUsedEndpoints() []string {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	return f.usedEndpoints
 }
 
 // AuthToken returns auth token

--- a/test/helper/fake_cloud_controller_api.go
+++ b/test/helper/fake_cloud_controller_api.go
@@ -74,7 +74,9 @@ func (f *FakeCloudControllerAPI) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 
 	f.ReceivedContents <- contents
 	f.ReceivedRequests <- r
+	f.lock.Lock()
 	f.UsedEndpoints = append(f.UsedEndpoints, r.URL.Path)
+	f.lock.Unlock()
 
 	time.Sleep(f.RequestTime * time.Millisecond)
 	f.writeResponse(rw, r)


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Implements extraction of Org memory quotas for all orgs. There's one TODO left in the code - I'm uncertain whether we want to provide a `host` for the org quota metrics. I think not, as orgs are not tied to a specific host, but I'd like to hear more opinions.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
