### PR TITLE
Decrease default batch size for API V3

### DIFF
--- a/config/datadog-firehose-nozzle.json
+++ b/config/datadog-firehose-nozzle.json
@@ -19,7 +19,7 @@
   "DisableAccessControl": false,
   "IdleTimeoutSeconds" : 60,
   "CloudControllerEndpoint": "string",
-  "CloudControllerAPIBatchSize": 2500,
+  "CloudControllerAPIBatchSize": 500,
   "AppMetrics": true,
   "NumWorkers": 1,
   "CustomTags": []

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultCloudControllerAPIBatchSize uint32 = 2500
+	defaultCloudControllerAPIBatchSize uint32 = 500
 	defaultGrabInterval                int    = 10
 	defaultWorkers                     int    = 4
 	defaultIdleTimeoutSeconds          uint32 = 60

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,7 +53,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.IdleTimeoutSeconds).To(BeEquivalentTo(60))
 		Expect(conf.WorkerTimeoutSeconds).To(BeEquivalentTo(10))
 		Expect(conf.GrabInterval).To(Equal(10))
-		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(2500))
+		Expect(conf.CloudControllerAPIBatchSize).To(BeEquivalentTo(500))
 	})
 
 	It("successfully overwrites file config values with environmental variables", func() {


### PR DESCRIPTION
### What does this PR do?

Based on some real-world large deployments, it looks like small batch sizes with V3 are still
extremely fast (so usable), while large batch sizes might make cloud controller run out of
memory and be killed from time to time

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
