### PR TITLE
When nozzle.Stop() is called, let closing OrgCollector to rest of Start() method

### DIFF
--- a/internal/nozzle/nozzle.go
+++ b/internal/nozzle/nozzle.go
@@ -213,9 +213,6 @@ func (n *Nozzle) Stop() {
 	// We only push value to the `stopper` channel of the Nozzle.
 	// Hence, if the nozzle is running (`run` method)
 	n.stopper <- true
-	if n.orgCollector != nil {
-		n.orgCollector.Stop()
-	}
 }
 
 // PostMetrics posts metrics do to datadog


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition in stopping the OrgCollector. Calling the `nozzle.Stop()` method actually causes the rest of the `nozzle.Start()` method to be unblocked (as the `nozzle.run()` method returns), so with the previous code they would both try to call `nozzle.OrgCollector.Stop()`. As this pushes value to a channel of size 0, one of the nozzle methods would get blocked. Most often it would be `nozzle.Start`, which we execute as goroutine in tests, hence I did not notice. Sometimes it would be `nozzle.Stop` though, so some randomly hanging tests revealed this issue.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
