### PR TITLE
Support loggregator API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ properties:
         override: true
         secret: <password>
         scope: openid,oauth.approvals,doppler.firehose
-        authorities: oauth.login,doppler.firehose
+        # TODO: verify that this is correct
+        authorities: oauth.login,doppler.firehose,logs.admin
 ```
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ properties:
         authorized-grant-types: authorization_code,client_credentials,refresh_token
         override: true
         secret: <password>
-        scope: openid,oauth.approvals,doppler.firehose
-        # TODO: verify that this is correct
-        authorities: oauth.login,doppler.firehose,logs.admin
+        scope: openid,oauth.approvals,logs.admin,cloud_controller.admin_read_only
+        authorities: oauth.login,logs.admin,cloud_controller.admin_read_only
 ```
 
 ### Dependencies

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,28 @@
-hash: e5e4e1f26dfffb38423c04d0c2899b4577380df3c85daeb2cf52371bffb97772
-updated: 2019-10-09T13:49:42.693908+02:00
+hash: 84f200db96cb77b0c97e5718363de985a4af62bf5e4e3ea5ef0df265dfb43ca6
+updated: 2019-10-29T15:27:46.414011+01:00
 imports:
+- name: code.cloudfoundry.org/go-diodes
+  version: f77fb823c7ee0156ed4cdadaf4f79ac3fd84613f
+- name: code.cloudfoundry.org/go-loggregator
+  version: b8d176783c8a6280a34f0e19e0e8f57d722773a1
+  subpackages:
+  - rpc/loggregator_v2
 - name: code.cloudfoundry.org/gofileutils
   version: 4d0c80011a0f37da1711c184028bc40137cd45af
   subpackages:
   - fileutils
 - name: code.cloudfoundry.org/localip
   version: b88ad0dea95cd41f302cf7eb6ed951efafaf47f2
+- name: code.cloudfoundry.org/rfc5424
+  version: 236a6d29298aea12f69978f33393d12465abc429
 - name: github.com/cloudfoundry-community/go-cfclient
   version: 35bcce23fc5f8b9969723ac38c0de1f82c4d3471
 - name: github.com/cloudfoundry-incubator/uaago
   version: be6a0cef0130f933079e4c958abac60fadea0c85
+- name: github.com/cloudfoundry/go-loggregator
+  version: b8d176783c8a6280a34f0e19e0e8f57d722773a1
+  subpackages:
+  - rpc/loggregator_v2
 - name: github.com/cloudfoundry/gosteno
   version: 0c8581caea35ac903728230e447792e2365dcc34
   subpackages:
@@ -22,7 +34,7 @@ imports:
   - consumer/internal
   - errors
 - name: github.com/cloudfoundry/sonde-go
-  version: 78019103037ae46207993c8816e970d85bf1a9e4
+  version: b33733203bb48d7c56de7cb639d77f78b0449d19
   subpackages:
   - events
 - name: github.com/gogo/protobuf
@@ -32,33 +44,79 @@ imports:
   - proto
   - protoc-gen-gogo/descriptor
 - name: github.com/golang/protobuf
-  version: 1e59b77b52bf8e4b449a57e6f79f21226d571845
+  version: ed6926b37a637426117ccab59282c3839528a700
   subpackages:
+  - jsonpb
   - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/struct
+  - ptypes/timestamp
 - name: github.com/gorilla/websocket
   version: c3e18be99d19e6b3e8f1559eea2c161a665c4b6b
 - name: github.com/hashicorp/go-cleanhttp
-  version: 3573b8b52aa7b37b9358d966a898feb387f62437
+  version: d3fcbee8e1810ecee4bdbf415f42f84cfd0e3361
 - name: github.com/hashicorp/go-retryablehttp
   version: 85a8ee556d7323a4faf0f4c17ee900e9ff1482e8
+- name: github.com/mailru/easyjson
+  version: 6c0755d89d1e153c9986ad90e886a626bd66aad0
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
 - name: github.com/Masterminds/semver
   version: fe7c21038085e01e67044ec1efe3afb1eaa59f75
 - name: github.com/pkg/errors
   version: ba968bfe8b2f7e042a574c888954fccecfa385b4
 - name: golang.org/x/net
-  version: db8e4de5b2d6653f66aea53094624468caad15d2
+  version: fe3aa8a4527195a6057b3fad46619d7d090e99b5
   subpackages:
   - context
+  - context/ctxhttp
   - html
   - html/atom
   - html/charset
+  - http/httpguts
+  - http2
+  - http2/hpack
+  - idna
+  - internal/timeseries
+  - trace
 - name: golang.org/x/oauth2
-  version: b5adcc2dcdf009d0391547edc6ecbaff889f5bb9
+  version: 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
   subpackages:
   - clientcredentials
   - internal
+- name: golang.org/x/sys
+  version: 195ce5e7f934b923d8fc432cf5a2561f2b334da9
+  subpackages:
+  - unix
+- name: golang.org/x/text
+  version: 3d0f7978add91030e5e8976ff65ccdd828286cba
+  subpackages:
+  - encoding
+  - encoding/charmap
+  - encoding/htmlindex
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/japanese
+  - encoding/korean
+  - encoding/simplifiedchinese
+  - encoding/traditionalchinese
+  - encoding/unicode
+  - internal/language
+  - internal/language/compact
+  - internal/tag
+  - internal/utf8internal
+  - language
+  - runes
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
 - name: google.golang.org/appengine
-  version: 9d8544a6b2c7df9cff240fcf92d7b2f59bc13416
+  version: 16bce7d3dc4e458f2f6f56a1349cbbfcdc8a8fdf
   subpackages:
   - internal
   - internal/base
@@ -67,6 +125,46 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
+- name: google.golang.org/genproto
+  version: 919d9bdd9fe6f1a5dd95ce5d5e4cdb8fd3c516d0
+  subpackages:
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: 4ec516e58900fb35115553b525e0fb7eb29fd6e3
+  subpackages:
+  - backoff
+  - balancer
+  - balancer/base
+  - balancer/roundrobin
+  - binarylog/grpc_binarylog_v1
+  - codes
+  - connectivity
+  - credentials
+  - credentials/internal
+  - encoding
+  - encoding/proto
+  - grpclog
+  - internal
+  - internal/backoff
+  - internal/balancerload
+  - internal/binarylog
+  - internal/channelz
+  - internal/envconfig
+  - internal/grpcrand
+  - internal/grpcsync
+  - internal/resolver/dns
+  - internal/resolver/passthrough
+  - internal/syscall
+  - internal/transport
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - resolver
+  - serviceconfig
+  - stats
+  - status
+  - tap
 testImports:
 - name: github.com/hpcloud/tail
   version: a1dbeea552b7c8df4b542c66073e393de198a800
@@ -111,28 +209,9 @@ testImports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
-- name: golang.org/x/sys
-  version: 39e3dc274464e7d2f663aa606a830611bae5f1db
-  subpackages:
-  - unix
-- name: golang.org/x/text
-  version: 3d0f7978add91030e5e8976ff65ccdd828286cba
-  subpackages:
-  - encoding
-  - encoding/charmap
-  - encoding/internal
-  - encoding/internal/identifier
-  - encoding/japanese
-  - encoding/korean
-  - encoding/simplifiedchinese
-  - encoding/traditionalchinese
-  - encoding/unicode
-  - internal/utf8internal
-  - runes
-  - transform
 - name: gopkg.in/fsnotify/fsnotify.v1
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: gopkg.in/tomb.v1
   version: c131134a1947e9afd9cecfe11f4c6dff0732ae58
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: f221b8435cfb71e54062f6c6e99e9ade30b124d5

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,9 +11,6 @@ import:
   subpackages:
   - consumer
   - errors
-- package: github.com/cloudfoundry/sonde-go
-  subpackages:
-  - events
 - package: github.com/gogo/protobuf
   version: ~0.4.0
   subpackages:
@@ -26,6 +23,8 @@ import:
   version: ~1.4.0
 - package: github.com/hashicorp/go-retryablehttp
   version: ~0.5.4
+- package: code.cloudfoundry.org/go-loggregator
+  version: ~7.7.0
 testImport:
 - package: github.com/onsi/ginkgo
   version: ~1.7.0

--- a/internal/client/cloudfoundry/loggregator_client.go
+++ b/internal/client/cloudfoundry/loggregator_client.go
@@ -1,0 +1,104 @@
+package cloudfoundry
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+
+	"github.com/DataDog/datadog-firehose-nozzle/internal/config"
+	"github.com/DataDog/datadog-firehose-nozzle/internal/logger"
+
+	"code.cloudfoundry.org/go-loggregator"
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"github.com/cloudfoundry/gosteno"
+)
+
+type LoggregatorClient struct {
+	RLPGatewayClient *loggregator.RLPGatewayClient
+	stopConsumer     context.CancelFunc
+	shardId          string
+}
+
+type rlpGatewayClientDoer struct {
+	token  string
+	client *http.Client
+}
+
+func (d *rlpGatewayClientDoer) Do(req *http.Request) (*http.Response, error) {
+	req.Header.Set("Authorization", d.token)
+	return d.client.Do(req)
+}
+
+func newRLPGatewayClientDoer(token string, insecureSkipVerify bool) *rlpGatewayClientDoer {
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecureSkipVerify,
+			},
+		},
+	}
+
+	return &rlpGatewayClientDoer{
+		token:  token,
+		client: client,
+	}
+}
+
+func NewLoggregatorClient(cfg *config.Config, lgr *gosteno.Logger, authToken string) (*LoggregatorClient, error) {
+	var logStreamURL string
+	if cfg.RLPGatewayURL != "" {
+		logStreamURL = cfg.RLPGatewayURL
+	} else if cfg.CloudControllerEndpoint != "" {
+		re := regexp.MustCompile("://(api)")
+		logStreamURL = re.ReplaceAllString(cfg.CloudControllerEndpoint, "://log-stream")
+	} else {
+		return nil, fmt.Errorf("neither CloudControllerEndpoint nor RLPGatewayURL specified, can't determine log stream URL")
+	}
+
+	logForwarder := *logger.NewRLPLogForwarder(lgr)
+	return &LoggregatorClient{
+		RLPGatewayClient: loggregator.NewRLPGatewayClient(
+			logStreamURL,
+			loggregator.WithRLPGatewayClientLogger(log.New(logForwarder, "", log.LstdFlags)),
+			loggregator.WithRLPGatewayHTTPClient(
+				newRLPGatewayClientDoer(authToken, cfg.InsecureSSLSkipVerify),
+			),
+		),
+		shardId:      cfg.FirehoseSubscriptionID,
+		stopConsumer: nil,
+	}, nil
+}
+
+func (l *LoggregatorClient) EnvelopeStream() loggregator.EnvelopeStream {
+	ctx := context.Background()
+	ctx, l.stopConsumer = context.WithCancel(context.Background())
+	es := l.RLPGatewayClient.Stream(
+		ctx,
+		&loggregator_v2.EgressBatchRequest{
+			ShardId: l.shardId,
+			Selectors: []*loggregator_v2.Selector{
+				{
+					Message: &loggregator_v2.Selector_Counter{
+						Counter: &loggregator_v2.CounterSelector{},
+					},
+				},
+				{
+					Message: &loggregator_v2.Selector_Gauge{
+						Gauge: &loggregator_v2.GaugeSelector{},
+					},
+				},
+			},
+		},
+	)
+
+	return es
+}
+
+func (l *LoggregatorClient) Stop() {
+	if l.stopConsumer != nil {
+		l.stopConsumer()
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	UAAURL                      string
 	Client                      string
 	ClientSecret                string
-	TrafficControllerURL        string
+	RLPGatewayURL               string
 	FirehoseSubscriptionID      string
 	DataDogURL                  string
 	DataDogAPIKey               string
@@ -104,7 +104,7 @@ func Parse(configPath string) (*Config, error) {
 	overrideWithEnvVar("NOZZLE_UAAURL", &config.UAAURL)
 	overrideWithEnvVar("NOZZLE_CLIENT", &config.Client)
 	overrideWithEnvVar("NOZZLE_CLIENT_SECRET", &config.ClientSecret)
-	overrideWithEnvVar("NOZZLE_TRAFFICCONTROLLERURL", &config.TrafficControllerURL)
+	overrideWithEnvVar("NOZZLE_RLP_GATEWAY_URL", &config.RLPGatewayURL)
 	overrideWithEnvVar("NOZZLE_FIREHOSESUBSCRIPTIONID", &config.FirehoseSubscriptionID)
 	overrideWithEnvVar("NOZZLE_DATADOGURL", &config.DataDogURL)
 	overrideWithEnvVar("NOZZLE_DATADOGAPIKEY", &config.DataDogAPIKey)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.UAAURL).To(Equal("https://uaa.walnut.cf-app.com"))
 		Expect(conf.Client).To(Equal("user"))
 		Expect(conf.ClientSecret).To(Equal("user_password"))
+		Expect(conf.RLPGatewayURL).To(Equal("https://some-url.blah"))
 		Expect(conf.DataDogURL).To(Equal("https://app.datadoghq.com/api/v1/series"))
 		Expect(conf.DataDogAPIKey).To(Equal("<enter api key>"))
 		Expect(conf.HTTPProxyURL).To(Equal("http://user:password@host.com:port"))
@@ -62,6 +63,7 @@ var _ = Describe("NozzleConfig", func() {
 		os.Setenv("NOZZLE_UAAURL", "https://uaa.walnut-env.cf-app.com")
 		os.Setenv("NOZZLE_CLIENT", "env-user")
 		os.Setenv("NOZZLE_CLIENT_SECRET", "env-user-password")
+		os.Setenv("NOZZLE_RLP_GATEWAY_URL", "https://even-more-different.com")
 		os.Setenv("NOZZLE_DATADOGURL", "https://app.datadoghq-env.com/api/v1/series")
 		os.Setenv("NOZZLE_DATADOGAPIKEY", "envapi-key>")
 		os.Setenv("HTTP_PROXY", "http://test:proxy")
@@ -88,6 +90,7 @@ var _ = Describe("NozzleConfig", func() {
 		Expect(conf.UAAURL).To(Equal("https://uaa.walnut-env.cf-app.com"))
 		Expect(conf.Client).To(Equal("env-user"))
 		Expect(conf.ClientSecret).To(Equal("env-user-password"))
+		Expect(conf.RLPGatewayURL).To(Equal("https://even-more-different.com"))
 		Expect(conf.DataDogURL).To(Equal("https://app.datadoghq-env.com/api/v1/series"))
 		Expect(conf.DataDogAPIKey).To(Equal("envapi-key>"))
 		Expect(conf.HTTPProxyURL).To(Equal("http://test:proxy"))
@@ -122,7 +125,7 @@ var _ = Describe("NozzleConfig", func() {
 		expected += `"GrabInterval":50,"HTTPProxyURL":"http://user:password@host.com:port",`
 		expected += `"HTTPSProxyURL":"https://user:password@host.com:port","IdleTimeoutSeconds":60,"InsecureSSLSkipVerify":true,`
 		expected += `"MetricPrefix":"datadogclient","NoProxy":[""],"NumCacheWorkers":2,"NumWorkers":1,`
-		expected += `"OrgDataCollectionInterval":100,"TrafficControllerURL":"wss://doppler.walnut.cf-app.com:4443",`
+		expected += `"OrgDataCollectionInterval":100,"RLPGatewayURL":"https://some-url.blah",`
 		expected += `"UAAURL":"https://uaa.walnut.cf-app.com","WorkerTimeoutSeconds":30}`
 		conf, err := Parse("testdata/test_config.json")
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/config/testdata/test_config.json
+++ b/internal/config/testdata/test_config.json
@@ -2,7 +2,7 @@
   "UAAURL": "https://uaa.walnut.cf-app.com",
   "Client": "user",
   "ClientSecret": "user_password",
-  "TrafficControllerURL": "wss://doppler.walnut.cf-app.com:4443",
+  "RLPGatewayURL": "https://some-url.blah",
   "FirehoseSubscriptionID": "datadog-nozzle",
   "DataDogURL": "https://app.datadoghq.com/api/v1/series",
   "DataDogAPIKey": "<enter api key>",

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -36,3 +36,21 @@ func NewLogger(verbose bool, logFilePath, name string, syslogNamespace string) *
 
 	return logger
 }
+
+type RLPLogForwarder struct {
+	// The loggregator.WithRLPGatewayClientLogger only takes log.Logger as argument,
+	// so this forwarder serves as it's "output" to proxy logs to our gosteno.Logger
+	log *gosteno.Logger
+}
+
+func NewRLPLogForwarder(gostenoLog *gosteno.Logger) (*RLPLogForwarder) {
+	return &RLPLogForwarder{
+		log: gostenoLog,
+	}
+}
+
+func (f RLPLogForwarder) Write(p []byte) (n int, err error) {
+	message := "message forwarded from RLP client: " + string(p)
+	f.log.Debugf(message)
+	return len(p), nil
+}

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -3,8 +3,6 @@ package metric
 import (
 	"errors"
 	"fmt"
-
-	"github.com/cloudfoundry/sonde-go/events"
 )
 
 type Point struct {
@@ -35,7 +33,6 @@ func (p *Point) UnmarshalJSON(in []byte) error {
 }
 
 type MetricKey struct {
-	EventType events.Envelope_EventType
 	Name      string
 	TagsHash  string
 }

--- a/internal/nozzle/nozzle.go
+++ b/internal/nozzle/nozzle.go
@@ -229,8 +229,8 @@ func (n *Nozzle) startFirehoseConsumer(authToken string) error {
 	})
 
 	go func(messages chan *loggregator_v2.Envelope, es loggregator.EnvelopeStream) {
-		// TODO: it seems that no errors are returned; they're only logged and the underlying
-		// logic retries forever, so we don't need the errors channel any more with loggregator v2 (?)
+		// NOTE: errors in the underlying es() function calls are not returned; they're only logged and
+		// the logic retries forever.
 		for {
 			for _, e := range es() {
 				messages <- e

--- a/internal/processor/parser/app.go
+++ b/internal/processor/parser/app.go
@@ -268,7 +268,7 @@ func (a *App) getMetrics(customTags []string) ([]metric.MetricPackage, error) {
 	return a.mkMetrics(names, ms, customTags)
 }
 
-func (a *App) parseContainerMetric(message *loggregator_v2.Gauge, instanceId string, customTags []string) ([]metric.MetricPackage, error) {
+func (a *App) parseContainerMetric(message *loggregator_v2.Gauge, instanceID string, customTags []string) ([]metric.MetricPackage, error) {
 	var names = []string{
 		"app.cpu.pct",
 		"app.disk.used",
@@ -285,7 +285,7 @@ func (a *App) parseContainerMetric(message *loggregator_v2.Gauge, instanceId str
 		float64(message.GetMetrics()["memory"].Value),
 		float64(message.GetMetrics()["memory_quota"].Value),
 	}
-	tags := []string{fmt.Sprintf("instance:%v", instanceId)}
+	tags := []string{fmt.Sprintf("instance:%v", getContainerInstanceID(message, instanceID))}
 	tags = append(tags, customTags...)
 	return a.mkMetrics(names, ms, tags)
 }

--- a/internal/processor/parser/app_test.go
+++ b/internal/processor/parser/app_test.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	. "github.com/DataDog/datadog-firehose-nozzle/test/helper"
-	"github.com/gogo/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
 	"github.com/cloudfoundry/gosteno"
-	"github.com/cloudfoundry/sonde-go/events"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/client/cloudfoundry"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/config"
 )
@@ -108,25 +107,43 @@ var _ = Describe("AppMetrics", func() {
 			Expect(err).To(BeNil())
 			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
 
-			event := &events.Envelope{
-				Origin:    proto.String("test-origin"),
-				Timestamp: proto.Int64(1000000000),
-				EventType: events.Envelope_ContainerMetric.Enum(),
-
-				ContainerMetric: &events.ContainerMetric{
-					CpuPercentage:    proto.Float64(float64(1)),
-					DiskBytes:        proto.Uint64(uint64(1)),
-					DiskBytesQuota:   proto.Uint64(uint64(1)),
-					MemoryBytes:      proto.Uint64(uint64(1)),
-					MemoryBytesQuota: proto.Uint64(uint64(1)),
-					ApplicationId:    proto.String("6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a"),
+			event := &loggregator_v2.Envelope{
+				Timestamp: 1000000000,
+				SourceId: "6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a",
+				InstanceId: "4",
+				Tags: map[string]string{
+					"origin": "test-origin",
+					"deployment": "deployment-name",
+					"job": "doppler",
+					"index": "1",
+					"ip": "10.0.1.2",
 				},
-
-				// fields that gets sent as tags
-				Deployment: proto.String("deployment-name"),
-				Job:        proto.String("doppler"),
-				Index:      proto.String("1"),
-				Ip:         proto.String("10.0.1.2"),
+				Message: &loggregator_v2.Envelope_Gauge{
+					Gauge: &loggregator_v2.Gauge{
+						Metrics: map[string]*loggregator_v2.GaugeValue{
+							"cpu": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"memory": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"disk": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"memory_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"disk_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+						},
+					},
+				},
 			}
 
 			metrics, err := a.Parse(event)
@@ -160,25 +177,43 @@ var _ = Describe("AppMetrics", func() {
 			Expect(err).To(BeNil())
 			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
 
-			event := &events.Envelope{
-				Origin:    proto.String("test-origin"),
-				Timestamp: proto.Int64(1000000000),
-				EventType: events.Envelope_ContainerMetric.Enum(),
-
-				ContainerMetric: &events.ContainerMetric{
-					CpuPercentage:    proto.Float64(float64(1)),
-					DiskBytes:        proto.Uint64(uint64(1)),
-					DiskBytesQuota:   proto.Uint64(uint64(1)),
-					MemoryBytes:      proto.Uint64(uint64(1)),
-					MemoryBytesQuota: proto.Uint64(uint64(1)),
-					ApplicationId:    proto.String("6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a"),
+			event := &loggregator_v2.Envelope{
+				Timestamp: 1000000000,
+				SourceId: "6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a",
+				InstanceId: "4",
+				Tags: map[string]string{
+					"origin": "test-origin",
+					"deployment": "deployment-name",
+					"job": "doppler",
+					"index": "1",
+					"ip": "10.0.1.2",
 				},
-
-				// fields that gets sent as tags
-				Deployment: proto.String("deployment-name"),
-				Job:        proto.String("doppler"),
-				Index:      proto.String("1"),
-				Ip:         proto.String("10.0.1.2"),
+				Message: &loggregator_v2.Envelope_Gauge{
+					Gauge: &loggregator_v2.Gauge{
+						Metrics: map[string]*loggregator_v2.GaugeValue{
+							"cpu": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"memory": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"disk": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"memory_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"disk_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+						},
+					},
+				},
 			}
 
 			metrics, err := a.Parse(event)

--- a/internal/processor/parser/app_test.go
+++ b/internal/processor/parser/app_test.go
@@ -170,6 +170,79 @@ var _ = Describe("AppMetrics", func() {
 		})
 	})
 
+	Context("expected tags", func() {
+		It("adds proper instance tag", func() {
+			a, err := NewAppParser(fakeCfClient, 5, 10, log, []string{}, "env_name")
+			Expect(err).To(BeNil())
+			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
+
+			event := &loggregator_v2.Envelope{
+				Timestamp: 1000000000,
+				SourceId: "6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a",
+				InstanceId: "4",
+				Tags: map[string]string{
+					"origin": "test-origin",
+					"deployment": "deployment-name",
+					"job": "doppler",
+					"index": "1",
+					"ip": "10.0.1.2",
+				},
+				Message: &loggregator_v2.Envelope_Gauge{
+					Gauge: &loggregator_v2.Gauge{
+						Metrics: map[string]*loggregator_v2.GaugeValue{
+							"cpu": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"memory": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"disk": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"memory_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+							"disk_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(1),
+							},
+						},
+					},
+				},
+			}
+
+			metricsWithInstanceTag := map[string]bool{
+				"app.cpu.pct": true,
+				"app.disk.used": true,
+				"app.disk.quota": true,
+				"app.memory.used": true,
+				"app.memory.quota": true,
+			}
+
+			metrics, err := a.Parse(event)
+			Expect(metrics).To(HaveLen(10))
+			for _, metric := range metrics {
+				if metricsWithInstanceTag[metric.MetricKey.Name] {
+					Expect(metric.MetricValue.Tags).To(ContainElement("instance:4"))
+				}
+			}
+
+			// instance_index should be preferred over InstanceId
+			event.GetGauge().GetMetrics()["instance_index"] = &loggregator_v2.GaugeValue{Value: float64(3)}
+			metrics, err = a.Parse(event)
+			Expect(metrics).To(HaveLen(10))
+			for _, metric := range metrics {
+				if metricsWithInstanceTag[metric.MetricKey.Name] {
+					Expect(metric.MetricValue.Tags).To(ContainElement("instance:3"))
+				}
+			}
+		})
+	})
+
 	Context("custom tags", func() {
 		It("attaches custom tags if present", func() {
 			a, err := NewAppParser(fakeCfClient, 5, 10, log, []string{"custom:tag", "foo:bar"},

--- a/internal/processor/parser/app_test.go
+++ b/internal/processor/parser/app_test.go
@@ -166,6 +166,7 @@ var _ = Describe("AppMetrics", func() {
 				Expect(metric.MetricValue.Tags).To(ContainElement("app_name:hello-datadog-cf-ruby-dev"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("guid:6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("env:env_name"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("source_id:6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a"))
 			}
 		})
 	})

--- a/internal/processor/parser/infra.go
+++ b/internal/processor/parser/infra.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/util"
-	"github.com/cloudfoundry/sonde-go/events"
+
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
 )
 
 type InfraParser struct {
@@ -31,109 +32,114 @@ func NewInfraParser(
 	}, nil
 }
 
-func (p InfraParser) Parse(envelope *events.Envelope) ([]metric.MetricPackage, error) {
+func (p InfraParser) Parse(envelope *loggregator_v2.Envelope) ([]metric.MetricPackage, error) {
 	metrics := []metric.MetricPackage{}
 
-	eventType := envelope.GetEventType()
-	if eventType != events.Envelope_ValueMetric && eventType != events.Envelope_CounterEvent {
+	switch envelope.GetMessage().(type) {
+	case *loggregator_v2.Envelope_Counter:
+		break
+	case *loggregator_v2.Envelope_Gauge:
+		if !util.IsContainerMetric(envelope) {
+			break
+		}
+		// if it's container metric, return error (we don't handle container metrics here)
+		// NOTE: `fallthrough` is not allowed in type switch
+		return metrics, fmt.Errorf("not an infra metric")
+	default:
 		return metrics, fmt.Errorf("not an infra metric")
 	}
 
 	host := parseHost(envelope)
-	name := getName(envelope)
 	tags := parseTags(envelope, p.Environment, p.DeploymentUUIDRegex, p.JobPartitionUUIDRegex)
 	tags = append(tags, p.CustomTags...)
 	tagsHash := util.HashTags(tags)
 
-	// create metricValues
-	metricValues := metric.MetricValue{}
-	metricValues.Host = host
-	metricValues.Tags = tags
-	value := getValue(envelope)
-	// NOTE: Value only has one point!!!!!!!!
-	metricValues.Points = append(metricValues.Points, metric.Point{
-		Timestamp: envelope.GetTimestamp() / int64(time.Second),
-		Value:     value,
-	})
-
-	var names []string
-	// Basic metric name
-	names = append(names, name)
-	// Legacy metric name
-	names = append(names, envelope.GetOrigin()+"."+name)
-	// BOSH alias metric name
-	if strings.HasPrefix(name, "bosh-hm-forwarder") {
-		names = append(names, strings.Replace(name, "bosh-hm-forwarder", "bosh.healthmonitor", 1))
-	}
-
-	// Create metric for each names with same values
-	for i := 0; i < len(names); i++ {
-		metrics = append(metrics, metric.MetricPackage{
-			MetricKey: &metric.MetricKey{
-				EventType: eventType,
-				Name:      names[i],
-				TagsHash:  tagsHash,
-			},
-			MetricValue: &metricValues,
+	for name, value := range getValues(envelope) {
+		// create metricValues
+		metricValues := metric.MetricValue{}
+		metricValues.Host = host
+		metricValues.Tags = tags
+		metricValues.Points = append(metricValues.Points, metric.Point{
+			Timestamp: envelope.GetTimestamp() / int64(time.Second),
+			Value:     value,
 		})
+
+		var names []string
+		// Basic metric name
+		names = append(names, name)
+		// Legacy metric name
+		if origin, ok := envelope.GetTags()["origin"]; ok {
+			names = append(names, origin+"."+name)
+		}
+		// BOSH alias metric name
+		if strings.HasPrefix(name, "bosh-hm-forwarder") {
+			names = append(names, strings.Replace(name, "bosh-hm-forwarder", "bosh.healthmonitor", 1))
+		}
+
+		// Create metric for each names with same values
+		for i := 0; i < len(names); i++ {
+			metrics = append(metrics, metric.MetricPackage{
+				MetricKey: &metric.MetricKey{
+					Name:      names[i],
+					TagsHash:  tagsHash,
+				},
+				MetricValue: &metricValues,
+			})
+		}
 	}
 
 	return metrics, nil
 }
 
-func getName(envelope *events.Envelope) string {
-	switch envelope.GetEventType() {
-	case events.Envelope_ValueMetric:
-		return envelope.GetValueMetric().GetName()
-	case events.Envelope_CounterEvent:
-		return envelope.GetCounterEvent().GetName()
+func getValues(envelope *loggregator_v2.Envelope) map[string]float64 {
+	values := map[string]float64{}
+	switch envelope.GetMessage().(type) {
+	case *loggregator_v2.Envelope_Gauge:
+		for k, v := range envelope.GetGauge().GetMetrics() {
+			values[k] = v.Value
+		}
+	case *loggregator_v2.Envelope_Counter:
+		values[envelope.GetCounter().GetName()] = float64(envelope.GetCounter().GetTotal())
 	default:
 		panic("Unknown event type")
 	}
-}
-
-func getValue(envelope *events.Envelope) float64 {
-	switch envelope.GetEventType() {
-	case events.Envelope_ValueMetric:
-		return envelope.GetValueMetric().GetValue()
-	case events.Envelope_CounterEvent:
-		return float64(envelope.GetCounterEvent().GetTotal())
-	default:
-		panic("Unknown event type")
-	}
+	return values
 }
 
 func parseTags(
-	envelope *events.Envelope,
+	envelope *loggregator_v2.Envelope,
 	environment string,
 	deploymentUUIDRegex *regexp.Regexp,
 	jobPartitionUUIDRegex *regexp.Regexp) []string {
-	tags := appendTagIfNotEmpty(nil, "deployment", envelope.GetDeployment())
-	tags = appendTagIfNotEmpty(tags, "job", envelope.GetJob())
-	tags = appendTagIfNotEmpty(tags, "index", envelope.GetIndex())
-	tags = appendTagIfNotEmpty(tags, "ip", envelope.GetIp())
-	tags = appendTagIfNotEmpty(tags, "origin", envelope.GetOrigin())
-	tags = appendTagIfNotEmpty(tags, "name", envelope.GetOrigin())
+
+	var tags []string
 	for tname, tvalue := range envelope.GetTags() {
 		tags = appendTagIfNotEmpty(tags, tname, tvalue)
+	}
+	if origin, ok := envelope.GetTags()["origin"]; ok {
+		tags = appendTagIfNotEmpty(tags, "name", origin)
 	}
 
 	// Add an environment tag and another deployment tag with the uuid part replaced with environment name
 	tags = appendTagIfNotEmpty(tags, "env", environment)
-	newDeploymentTag := deploymentUUIDRegex.ReplaceAllString(envelope.GetDeployment(), "")
-	if environment != "" {
-		tags = appendTagIfNotEmpty(tags, "deployment", fmt.Sprintf("%s_%s", newDeploymentTag, environment))
-	}
-	// Do not duplicate tag
-	if newDeploymentTag != envelope.GetDeployment() {
-		tags = appendTagIfNotEmpty(tags, "deployment", newDeploymentTag)
+	if deployment, ok := envelope.GetTags()["deployment"]; ok {
+		newDeploymentTag := deploymentUUIDRegex.ReplaceAllString(deployment, "")
+		if environment != "" {
+			tags = appendTagIfNotEmpty(tags, "deployment", fmt.Sprintf("%s_%s", newDeploymentTag, environment))
+		}
+		// Do not duplicate tag
+		if newDeploymentTag != deployment {
+			tags = appendTagIfNotEmpty(tags, "deployment", newDeploymentTag)
+		}
 	}
 
 	// Add a new job tag with the partition uuid part replaced with its index an one with only the job name
-	newJobTag := jobPartitionUUIDRegex.ReplaceAllString(envelope.GetJob(), "")
-	// Do not duplicate tag
-	if newJobTag != envelope.GetJob() {
-		tags = appendTagIfNotEmpty(tags, "job", newJobTag)
+	if job, ok := envelope.GetTags()["job"]; ok {
+		newJobTag := jobPartitionUUIDRegex.ReplaceAllString(job, "")
+		// Do not duplicate tag
+		if newJobTag != job {
+			tags = appendTagIfNotEmpty(tags, "job", newJobTag)
+		}
 	}
 
 	return tags

--- a/internal/processor/parser/infra.go
+++ b/internal/processor/parser/infra.go
@@ -119,6 +119,7 @@ func parseTags(
 	if origin, ok := envelope.GetTags()["origin"]; ok {
 		tags = appendTagIfNotEmpty(tags, "name", origin)
 	}
+	tags = appendTagIfNotEmpty(tags, "instance_id", envelope.GetInstanceId())
 
 	// Add an environment tag and another deployment tag with the uuid part replaced with environment name
 	tags = appendTagIfNotEmpty(tags, "env", environment)

--- a/internal/processor/parser/infra.go
+++ b/internal/processor/parser/infra.go
@@ -80,8 +80,8 @@ func (p InfraParser) Parse(envelope *loggregator_v2.Envelope) ([]metric.MetricPa
 		for i := 0; i < len(names); i++ {
 			metrics = append(metrics, metric.MetricPackage{
 				MetricKey: &metric.MetricKey{
-					Name:      names[i],
-					TagsHash:  tagsHash,
+					Name:     names[i],
+					TagsHash: tagsHash,
 				},
 				MetricValue: &metricValues,
 			})
@@ -120,6 +120,7 @@ func parseTags(
 		tags = appendTagIfNotEmpty(tags, "name", origin)
 	}
 	tags = appendTagIfNotEmpty(tags, "instance_id", envelope.GetInstanceId())
+	tags = appendTagIfNotEmpty(tags, "source_id", envelope.GetSourceId())
 
 	// Add an environment tag and another deployment tag with the uuid part replaced with environment name
 	tags = appendTagIfNotEmpty(tags, "env", environment)

--- a/internal/processor/parser/parser.go
+++ b/internal/processor/parser/parser.go
@@ -2,9 +2,10 @@ package parser
 
 import (
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
-	"github.com/cloudfoundry/sonde-go/events"
+
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
 )
 
 type Parser interface {
-	Parse(envelope *events.Envelope) ([]metric.MetricPackage, error)
+	Parse(envelope *loggregator_v2.Envelope) ([]metric.MetricPackage, error)
 }

--- a/internal/processor/parser/util.go
+++ b/internal/processor/parser/util.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
 )
 
@@ -21,4 +22,14 @@ func appendTagIfNotEmpty(tags []string, key, value string) []string {
 		tags = append(tags, fmt.Sprintf("%s:%s", key, value))
 	}
 	return tags
+}
+
+func getContainerInstanceID(gauge *loggregator_v2.Gauge, instanceID string) string {
+	if gauge == nil {
+		return ""
+	}
+	if id, ok := gauge.GetMetrics()["instance_index"]; ok && id != nil {
+		return strconv.Itoa(int(id.GetValue()))
+	}
+	return instanceID
 }

--- a/internal/processor/parser/util.go
+++ b/internal/processor/parser/util.go
@@ -2,15 +2,15 @@ package parser
 
 import (
 	"fmt"
-	"github.com/cloudfoundry/sonde-go/events"
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
 )
 
 
-func parseHost(envelope *events.Envelope) string {
-	if envelope.GetIndex() != "" {
-		return envelope.GetIndex()
-	} else if envelope.GetOrigin() != "" {
-		return envelope.GetOrigin()
+func parseHost(envelope *loggregator_v2.Envelope) string {
+	if index, ok := envelope.GetTags()["index"]; ok && index != "" {
+		return index
+	} else if origin, ok := envelope.GetTags()["origin"]; ok && origin != "" {
+		return origin
 	}
 
 	return ""

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -22,18 +22,18 @@ var _ = Describe("MetricProcessor", func() {
 
 	It("processes value & counter metrics", func() {
 		p.ProcessMetric(&loggregator_v2.Envelope{
-			Timestamp: 1000000000,
+			Timestamp:  1000000000,
 			InstanceId: "123",
 			Tags: map[string]string{
-				"origin": "origin",
+				"origin":     "origin",
 				"deployment": "deployment-name",
-				"job": "doppler",
+				"job":        "doppler",
 			},
 			Message: &loggregator_v2.Envelope_Gauge{
 				Gauge: &loggregator_v2.Gauge{
 					Metrics: map[string]*loggregator_v2.GaugeValue{
 						"valueName": &loggregator_v2.GaugeValue{
-							Unit: "counter",
+							Unit:  "counter",
 							Value: float64(5),
 						},
 					},
@@ -41,16 +41,16 @@ var _ = Describe("MetricProcessor", func() {
 			},
 		})
 		p.ProcessMetric(&loggregator_v2.Envelope{
-			Timestamp: 2000000000,
+			Timestamp:  2000000000,
 			InstanceId: "123",
 			Tags: map[string]string{
-				"origin": "origin",
+				"origin":     "origin",
 				"deployment": "deployment-name",
-				"job": "doppler",
+				"job":        "doppler",
 			},
 			Message: &loggregator_v2.Envelope_Counter{
 				Counter: &loggregator_v2.Counter{
-					Name: "counterName",
+					Name:  "counterName",
 					Delta: uint64(6),
 					Total: uint64(11),
 				},
@@ -82,15 +82,15 @@ var _ = Describe("MetricProcessor", func() {
 		p.ProcessMetric(&loggregator_v2.Envelope{
 			Timestamp: 1000000000,
 			Tags: map[string]string{
-				"origin": "origin",
+				"origin":     "origin",
 				"deployment": "deployment-name",
-				"job": "doppler",
+				"job":        "doppler",
 			},
 			Message: &loggregator_v2.Envelope_Gauge{
 				Gauge: &loggregator_v2.Gauge{
 					Metrics: map[string]*loggregator_v2.GaugeValue{
 						"fooMetric": &loggregator_v2.GaugeValue{
-							Unit: "counter",
+							Unit:  "counter",
 							Value: float64(5),
 						},
 					},
@@ -120,19 +120,19 @@ var _ = Describe("MetricProcessor", func() {
 		p.ProcessMetric(&loggregator_v2.Envelope{
 			Timestamp: 1000000000,
 			Tags: map[string]string{
-				"origin": "origin",
+				"origin":     "origin",
 				"deployment": "deployment-name",
-				"job": "doppler",
+				"job":        "doppler",
 			},
 			Message: &loggregator_v2.Envelope_Gauge{
 				Gauge: &loggregator_v2.Gauge{
 					Metrics: map[string]*loggregator_v2.GaugeValue{
 						"fooMetric": &loggregator_v2.GaugeValue{
-							Unit: "counter",
+							Unit:  "counter",
 							Value: float64(5),
 						},
 						"barMetric": &loggregator_v2.GaugeValue{
-							Unit: "counter",
+							Unit:  "counter",
 							Value: float64(6),
 						},
 					},
@@ -174,15 +174,15 @@ var _ = Describe("MetricProcessor", func() {
 		p.ProcessMetric(&loggregator_v2.Envelope{
 			Timestamp: 1000000000,
 			Tags: map[string]string{
-				"origin": "origin",
+				"origin":     "origin",
 				"deployment": "deployment-name",
-				"job": "doppler",
+				"job":        "doppler",
 			},
 			Message: &loggregator_v2.Envelope_Gauge{
 				Gauge: &loggregator_v2.Gauge{
 					Metrics: map[string]*loggregator_v2.GaugeValue{
 						"bosh-hm-forwarder.foo": &loggregator_v2.GaugeValue{
-							Unit: "counter",
+							Unit:  "counter",
 							Value: float64(5),
 						},
 					},
@@ -216,47 +216,47 @@ var _ = Describe("MetricProcessor", func() {
 		p.ProcessMetric(&loggregator_v2.Envelope{
 			Timestamp: 1000000000,
 			Tags: map[string]string{
-				"origin": "origin",
+				"origin":     "origin",
 				"deployment": "deployment-name",
-				"job": "doppler",
+				"job":        "doppler",
 			},
 			Message: &loggregator_v2.Envelope_Log{
 				Log: &loggregator_v2.Log{
 					Payload: []byte("log message"),
-					Type: loggregator_v2.Log_OUT,
+					Type:    loggregator_v2.Log_OUT,
 				},
 			},
 		})
 		p.ProcessMetric(&loggregator_v2.Envelope{
-			Timestamp: 1000000000,
-			SourceId: "app-id",
+			Timestamp:  1000000000,
+			SourceId:   "app-id",
 			InstanceId: "4",
 			Tags: map[string]string{
-				"origin": "origin",
+				"origin":     "origin",
 				"deployment": "deployment-name",
-				"job": "doppler",
+				"job":        "doppler",
 			},
 			Message: &loggregator_v2.Envelope_Gauge{
 				Gauge: &loggregator_v2.Gauge{
 					Metrics: map[string]*loggregator_v2.GaugeValue{
 						"cpu": &loggregator_v2.GaugeValue{
-							Unit: "gauge",
+							Unit:  "gauge",
 							Value: float64(20.0),
 						},
 						"memory": &loggregator_v2.GaugeValue{
-							Unit: "gauge",
+							Unit:  "gauge",
 							Value: float64(19939949),
 						},
 						"disk": &loggregator_v2.GaugeValue{
-							Unit: "gauge",
+							Unit:  "gauge",
 							Value: float64(29488929),
 						},
 						"memory_quota": &loggregator_v2.GaugeValue{
-							Unit: "gauge",
+							Unit:  "gauge",
 							Value: float64(19939949),
 						},
 						"disk_quota": &loggregator_v2.GaugeValue{
-							Unit: "gauge",
+							Unit:  "gauge",
 							Value: float64(29488929),
 						},
 					},
@@ -270,19 +270,20 @@ var _ = Describe("MetricProcessor", func() {
 	It("adds tags", func() {
 		p.ProcessMetric(&loggregator_v2.Envelope{
 			Timestamp: 1000000000,
+			SourceId:  "some.source",
 			Tags: map[string]string{
-				"origin": "test-origin",
+				"origin":     "test-origin",
 				"deployment": "deployment-name-aaaaaaaaaaaaaaaaaaaa",
-				"job": "doppler-partition-aaaaaaaaaaaaaaaaaaaa",
-				"ip": "10.0.1.2",
-				"protocol": "http",
+				"job":        "doppler-partition-aaaaaaaaaaaaaaaaaaaa",
+				"ip":         "10.0.1.2",
+				"protocol":   "http",
 				"request_id": "a1f5-deadbeef",
 			},
 			Message: &loggregator_v2.Envelope_Gauge{
 				Gauge: &loggregator_v2.Gauge{
 					Metrics: map[string]*loggregator_v2.GaugeValue{
 						"fooMetric": &loggregator_v2.GaugeValue{
-							Unit: "counter",
+							Unit:  "counter",
 							Value: float64(5),
 						},
 					},
@@ -305,6 +306,7 @@ var _ = Describe("MetricProcessor", func() {
 				"origin:test-origin",
 				"protocol:http",
 				"request_id:a1f5-deadbeef",
+				"source_id:some.source",
 			}))
 		}
 
@@ -313,19 +315,19 @@ var _ = Describe("MetricProcessor", func() {
 		p.ProcessMetric(&loggregator_v2.Envelope{
 			Timestamp: 1000000000,
 			Tags: map[string]string{
-				"origin": "test-origin",
+				"origin":     "test-origin",
 				"deployment": "deployment-name-aaaaaaaaaaaaaaaaaaaa",
-				"job": "doppler-partition-aaaaaaaaaaaaaaaaaaaa",
-				"ip": "10.0.1.2",
-				"protocol": "http",
+				"job":        "doppler-partition-aaaaaaaaaaaaaaaaaaaa",
+				"ip":         "10.0.1.2",
+				"protocol":   "http",
 				"request_id": "a1f5-deadbeef",
-				"index": "1",
+				"index":      "1",
 			},
 			Message: &loggregator_v2.Envelope_Gauge{
 				Gauge: &loggregator_v2.Gauge{
 					Metrics: map[string]*loggregator_v2.GaugeValue{
 						"fooMetric": &loggregator_v2.GaugeValue{
-							Unit: "counter",
+							Unit:  "counter",
 							Value: float64(5),
 						},
 					},
@@ -365,19 +367,19 @@ var _ = Describe("MetricProcessor", func() {
 			p.ProcessMetric(&loggregator_v2.Envelope{
 				Timestamp: 1000000000,
 				Tags: map[string]string{
-					"origin": "test-origin",
+					"origin":     "test-origin",
 					"deployment": "deployment-name",
-					"job": "doppler",
-					"ip": "10.0.1.2",
-					"protocol": "http",
+					"job":        "doppler",
+					"ip":         "10.0.1.2",
+					"protocol":   "http",
 					"request_id": "a1f5-deadbeef",
-					"index": "1",
+					"index":      "1",
 				},
 				Message: &loggregator_v2.Envelope_Gauge{
 					Gauge: &loggregator_v2.Gauge{
 						Metrics: map[string]*loggregator_v2.GaugeValue{
 							"fooMetric": &loggregator_v2.GaugeValue{
-								Unit: "counter",
+								Unit:  "counter",
 								Value: float64(5),
 							},
 						},

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -23,6 +23,7 @@ var _ = Describe("MetricProcessor", func() {
 	It("processes value & counter metrics", func() {
 		p.ProcessMetric(&loggregator_v2.Envelope{
 			Timestamp: 1000000000,
+			InstanceId: "123",
 			Tags: map[string]string{
 				"origin": "origin",
 				"deployment": "deployment-name",
@@ -41,6 +42,7 @@ var _ = Describe("MetricProcessor", func() {
 		})
 		p.ProcessMetric(&loggregator_v2.Envelope{
 			Timestamp: 2000000000,
+			InstanceId: "123",
 			Tags: map[string]string{
 				"origin": "origin",
 				"deployment": "deployment-name",
@@ -65,6 +67,7 @@ var _ = Describe("MetricProcessor", func() {
 
 		Expect(metricPkgs).To(HaveLen(4))
 		for _, m := range metricPkgs {
+			Expect(m.MetricValue.Tags).To(ContainElement("instance_id:123"))
 			if m.MetricKey.Name == "valueName" || m.MetricKey.Name == "origin.valueName" {
 				Expect(m.MetricValue.Points).To(Equal([]metric.Point{{Timestamp: 1, Value: 5.0}}))
 			} else if m.MetricKey.Name == "counterName" || m.MetricKey.Name == "origin.counterName" {

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -1,9 +1,8 @@
 package processor
 
 import (
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
-	"github.com/cloudfoundry/sonde-go/events"
-	"github.com/gogo/protobuf/proto"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -22,26 +21,37 @@ var _ = Describe("MetricProcessor", func() {
 	})
 
 	It("processes value & counter metrics", func() {
-		p.ProcessMetric(&events.Envelope{
-			Origin:    proto.String("origin"),
-			Timestamp: proto.Int64(1000000000),
-			EventType: events.Envelope_ValueMetric.Enum(),
-			ValueMetric: &events.ValueMetric{
-				Name:  proto.String("valueName"),
-				Value: proto.Float64(5),
+		p.ProcessMetric(&loggregator_v2.Envelope{
+			Timestamp: 1000000000,
+			Tags: map[string]string{
+				"origin": "origin",
+				"deployment": "deployment-name",
+				"job": "doppler",
 			},
-			Deployment: proto.String("deployment-name"),
-			Job:        proto.String("doppler"),
+			Message: &loggregator_v2.Envelope_Gauge{
+				Gauge: &loggregator_v2.Gauge{
+					Metrics: map[string]*loggregator_v2.GaugeValue{
+						"valueName": &loggregator_v2.GaugeValue{
+							Unit: "counter",
+							Value: float64(5),
+						},
+					},
+				},
+			},
 		})
-
-		p.ProcessMetric(&events.Envelope{
-			Origin:    proto.String("origin"),
-			Timestamp: proto.Int64(2000000000),
-			EventType: events.Envelope_CounterEvent.Enum(),
-			CounterEvent: &events.CounterEvent{
-				Name:  proto.String("counterName"),
-				Delta: proto.Uint64(6),
-				Total: proto.Uint64(11),
+		p.ProcessMetric(&loggregator_v2.Envelope{
+			Timestamp: 2000000000,
+			Tags: map[string]string{
+				"origin": "origin",
+				"deployment": "deployment-name",
+				"job": "doppler",
+			},
+			Message: &loggregator_v2.Envelope_Counter{
+				Counter: &loggregator_v2.Counter{
+					Name: "counterName",
+					Delta: uint64(6),
+					Total: uint64(11),
+				},
 			},
 		})
 
@@ -66,16 +76,23 @@ var _ = Describe("MetricProcessor", func() {
 	})
 
 	It("generates metrics twice: once with origin in name, once without", func() {
-		p.ProcessMetric(&events.Envelope{
-			Origin:    proto.String("origin"),
-			Timestamp: proto.Int64(1000000000),
-			EventType: events.Envelope_ValueMetric.Enum(),
-			ValueMetric: &events.ValueMetric{
-				Name:  proto.String("fooMetric"),
-				Value: proto.Float64(5),
+		p.ProcessMetric(&loggregator_v2.Envelope{
+			Timestamp: 1000000000,
+			Tags: map[string]string{
+				"origin": "origin",
+				"deployment": "deployment-name",
+				"job": "doppler",
 			},
-			Deployment: proto.String("deployment-name"),
-			Job:        proto.String("doppler"),
+			Message: &loggregator_v2.Envelope_Gauge{
+				Gauge: &loggregator_v2.Gauge{
+					Metrics: map[string]*loggregator_v2.GaugeValue{
+						"fooMetric": &loggregator_v2.GaugeValue{
+							Unit: "counter",
+							Value: float64(5),
+						},
+					},
+				},
+			},
 		})
 
 		var metricPkg []metric.MetricPackage
@@ -96,17 +113,78 @@ var _ = Describe("MetricProcessor", func() {
 		Expect(newFound).To(BeTrue())
 	})
 
-	It("adds a new alias for `bosh-hm-forwarder` metrics", func() {
-		p.ProcessMetric(&events.Envelope{
-			Origin:    proto.String("origin"),
-			Timestamp: proto.Int64(1000000000),
-			EventType: events.Envelope_ValueMetric.Enum(),
-			ValueMetric: &events.ValueMetric{
-				Name:  proto.String("bosh-hm-forwarder.foo"),
-				Value: proto.Float64(5),
+	It("extracts multiple values from Gauge if it has multiple metrics", func() {
+		p.ProcessMetric(&loggregator_v2.Envelope{
+			Timestamp: 1000000000,
+			Tags: map[string]string{
+				"origin": "origin",
+				"deployment": "deployment-name",
+				"job": "doppler",
 			},
-			Deployment: proto.String("deployment-name"),
-			Job:        proto.String("doppler"),
+			Message: &loggregator_v2.Envelope_Gauge{
+				Gauge: &loggregator_v2.Gauge{
+					Metrics: map[string]*loggregator_v2.GaugeValue{
+						"fooMetric": &loggregator_v2.GaugeValue{
+							Unit: "counter",
+							Value: float64(5),
+						},
+						"barMetric": &loggregator_v2.GaugeValue{
+							Unit: "counter",
+							Value: float64(6),
+						},
+					},
+				},
+			},
+		})
+
+		var metricPkg []metric.MetricPackage
+		Eventually(mchan).Should(Receive(&metricPkg))
+
+		Expect(metricPkg).To(HaveLen(4))
+
+		legacyFooFound := false
+		legacyBarFound := false
+		newFooFound := false
+		newBarFound := false
+		for _, m := range metricPkg {
+			if m.MetricKey.Name == "origin.fooMetric" {
+				legacyFooFound = true
+				Expect(m.MetricValue.Points[0].Value).To(Equal(5.0))
+			} else if m.MetricKey.Name == "fooMetric" {
+				newFooFound = true
+				Expect(m.MetricValue.Points[0].Value).To(Equal(5.0))
+			} else if m.MetricKey.Name == "origin.barMetric" {
+				legacyBarFound = true
+				Expect(m.MetricValue.Points[0].Value).To(Equal(6.0))
+			} else if m.MetricKey.Name == "barMetric" {
+				newBarFound = true
+				Expect(m.MetricValue.Points[0].Value).To(Equal(6.0))
+			}
+		}
+		Expect(legacyFooFound).To(BeTrue())
+		Expect(newFooFound).To(BeTrue())
+		Expect(legacyBarFound).To(BeTrue())
+		Expect(newBarFound).To(BeTrue())
+	})
+
+	It("adds a new alias for `bosh-hm-forwarder` metrics", func() {
+		p.ProcessMetric(&loggregator_v2.Envelope{
+			Timestamp: 1000000000,
+			Tags: map[string]string{
+				"origin": "origin",
+				"deployment": "deployment-name",
+				"job": "doppler",
+			},
+			Message: &loggregator_v2.Envelope_Gauge{
+				Gauge: &loggregator_v2.Gauge{
+					Metrics: map[string]*loggregator_v2.GaugeValue{
+						"bosh-hm-forwarder.foo": &loggregator_v2.GaugeValue{
+							Unit: "counter",
+							Value: float64(5),
+						},
+					},
+				},
+			},
 		})
 
 		var metricPkg []metric.MetricPackage
@@ -132,52 +210,80 @@ var _ = Describe("MetricProcessor", func() {
 	})
 
 	It("ignores messages that aren't value metrics or counter events", func() {
-		p.ProcessMetric(&events.Envelope{
-			Origin:    proto.String("origin"),
-			Timestamp: proto.Int64(1000000000),
-			EventType: events.Envelope_LogMessage.Enum(),
-			LogMessage: &events.LogMessage{
-				Message:     []byte("log message"),
-				MessageType: events.LogMessage_OUT.Enum(),
-				Timestamp:   proto.Int64(1000000000),
+		p.ProcessMetric(&loggregator_v2.Envelope{
+			Timestamp: 1000000000,
+			Tags: map[string]string{
+				"origin": "origin",
+				"deployment": "deployment-name",
+				"job": "doppler",
 			},
-			Deployment: proto.String("deployment-name"),
-			Job:        proto.String("doppler"),
+			Message: &loggregator_v2.Envelope_Log{
+				Log: &loggregator_v2.Log{
+					Payload: []byte("log message"),
+					Type: loggregator_v2.Log_OUT,
+				},
+			},
 		})
-
-		p.ProcessMetric(&events.Envelope{
-			Origin:    proto.String("origin"),
-			Timestamp: proto.Int64(1000000000),
-			EventType: events.Envelope_ContainerMetric.Enum(),
-			ContainerMetric: &events.ContainerMetric{
-				ApplicationId: proto.String("app-id"),
-				InstanceIndex: proto.Int32(4),
-				CpuPercentage: proto.Float64(20.0),
-				MemoryBytes:   proto.Uint64(19939949),
-				DiskBytes:     proto.Uint64(29488929),
+		p.ProcessMetric(&loggregator_v2.Envelope{
+			Timestamp: 1000000000,
+			SourceId: "app-id",
+			InstanceId: "4",
+			Tags: map[string]string{
+				"origin": "origin",
+				"deployment": "deployment-name",
+				"job": "doppler",
 			},
-			Deployment: proto.String("deployment-name"),
-			Job:        proto.String("doppler"),
+			Message: &loggregator_v2.Envelope_Gauge{
+				Gauge: &loggregator_v2.Gauge{
+					Metrics: map[string]*loggregator_v2.GaugeValue{
+						"cpu": &loggregator_v2.GaugeValue{
+							Unit: "gauge",
+							Value: float64(20.0),
+						},
+						"memory": &loggregator_v2.GaugeValue{
+							Unit: "gauge",
+							Value: float64(19939949),
+						},
+						"disk": &loggregator_v2.GaugeValue{
+							Unit: "gauge",
+							Value: float64(29488929),
+						},
+						"memory_quota": &loggregator_v2.GaugeValue{
+							Unit: "gauge",
+							Value: float64(19939949),
+						},
+						"disk_quota": &loggregator_v2.GaugeValue{
+							Unit: "gauge",
+							Value: float64(29488929),
+						},
+					},
+				},
+			},
 		})
 
 		Consistently(mchan).ShouldNot(Receive())
 	})
 
 	It("adds tags", func() {
-		p.ProcessMetric(&events.Envelope{
-			Origin:    proto.String("test-origin"),
-			Timestamp: proto.Int64(1000000000),
-			EventType: events.Envelope_ValueMetric.Enum(),
-
-			// fields that gets sent as tags
-			Deployment: proto.String("deployment-name-aaaaaaaaaaaaaaaaaaaa"),
-			Job:        proto.String("doppler-partition-aaaaaaaaaaaaaaaaaaaa"),
-			Ip:         proto.String("10.0.1.2"),
-
-			// additional tags
+		p.ProcessMetric(&loggregator_v2.Envelope{
+			Timestamp: 1000000000,
 			Tags: map[string]string{
-				"protocol":   "http",
+				"origin": "test-origin",
+				"deployment": "deployment-name-aaaaaaaaaaaaaaaaaaaa",
+				"job": "doppler-partition-aaaaaaaaaaaaaaaaaaaa",
+				"ip": "10.0.1.2",
+				"protocol": "http",
 				"request_id": "a1f5-deadbeef",
+			},
+			Message: &loggregator_v2.Envelope_Gauge{
+				Gauge: &loggregator_v2.Gauge{
+					Metrics: map[string]*loggregator_v2.GaugeValue{
+						"fooMetric": &loggregator_v2.GaugeValue{
+							Unit: "counter",
+							Value: float64(5),
+						},
+					},
+				},
 			},
 		})
 
@@ -201,21 +307,26 @@ var _ = Describe("MetricProcessor", func() {
 
 		// Check it does the correct dogate tag replacements when env_name and index are set
 		p.environment = "env_name"
-		p.ProcessMetric(&events.Envelope{
-			Origin:    proto.String("test-origin"),
-			Timestamp: proto.Int64(1000000000),
-			EventType: events.Envelope_ValueMetric.Enum(),
-
-			// fields that gets sent as tags
-			Deployment: proto.String("deployment-name-aaaaaaaaaaaaaaaaaaaa"),
-			Job:        proto.String("doppler-partition-aaaaaaaaaaaaaaaaaaaa"),
-			Index:      proto.String("1"),
-			Ip:         proto.String("10.0.1.2"),
-
-			// additional tags
+		p.ProcessMetric(&loggregator_v2.Envelope{
+			Timestamp: 1000000000,
 			Tags: map[string]string{
-				"protocol":   "http",
+				"origin": "test-origin",
+				"deployment": "deployment-name-aaaaaaaaaaaaaaaaaaaa",
+				"job": "doppler-partition-aaaaaaaaaaaaaaaaaaaa",
+				"ip": "10.0.1.2",
+				"protocol": "http",
 				"request_id": "a1f5-deadbeef",
+				"index": "1",
+			},
+			Message: &loggregator_v2.Envelope_Gauge{
+				Gauge: &loggregator_v2.Gauge{
+					Metrics: map[string]*loggregator_v2.GaugeValue{
+						"fooMetric": &loggregator_v2.GaugeValue{
+							Unit: "counter",
+							Value: float64(5),
+						},
+					},
+				},
 			},
 		})
 
@@ -248,21 +359,26 @@ var _ = Describe("MetricProcessor", func() {
 		})
 
 		It("adds custom tags to infra metrics", func() {
-			p.ProcessMetric(&events.Envelope{
-				Origin:    proto.String("test-origin"),
-				Timestamp: proto.Int64(1000000000),
-				EventType: events.Envelope_ValueMetric.Enum(),
-
-				// fields that gets sent as tags
-				Deployment: proto.String("deployment-name"),
-				Job:        proto.String("doppler"),
-				Index:      proto.String("1"),
-				Ip:         proto.String("10.0.1.2"),
-
-				// additional tags
+			p.ProcessMetric(&loggregator_v2.Envelope{
+				Timestamp: 1000000000,
 				Tags: map[string]string{
-					"protocol":   "http",
+					"origin": "test-origin",
+					"deployment": "deployment-name",
+					"job": "doppler",
+					"ip": "10.0.1.2",
+					"protocol": "http",
 					"request_id": "a1f5-deadbeef",
+					"index": "1",
+				},
+				Message: &loggregator_v2.Envelope_Gauge{
+					Gauge: &loggregator_v2.Gauge{
+						Metrics: map[string]*loggregator_v2.GaugeValue{
+							"fooMetric": &loggregator_v2.GaugeValue{
+								Unit: "counter",
+								Value: float64(5),
+							},
+						},
+					},
 				},
 			})
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -34,11 +34,12 @@ func GetTickerWithJitter(wholeIntervalSeconds uint32, jitterPct float64) (*time.
 }
 
 func IsContainerMetric(envelope *loggregator_v2.Envelope) bool {
+	// We can tell whether or not a Gauge envelope is container metric by checking
+	// a predefined set of metrics: https://github.com/cloudfoundry/loggregator-api#containermetric
 	result := false
 	switch envelope.GetMessage().(type) {
 	case *loggregator_v2.Envelope_Gauge:
 		result = true
-		// TOOD: verify that this is the right set of keys
 		for _, key := range []string{"cpu", "memory", "disk", "memory_quota", "disk_quota"} {
 			if _, ok := envelope.GetGauge().GetMetrics()[key]; !ok {
 				result = false

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -41,7 +41,7 @@ func IsContainerMetric(envelope *loggregator_v2.Envelope) bool {
 	case *loggregator_v2.Envelope_Gauge:
 		result = true
 		for _, key := range []string{"cpu", "memory", "disk", "memory_quota", "disk_quota"} {
-			if _, ok := envelope.GetGauge().GetMetrics()[key]; !ok {
+			if v, ok := envelope.GetGauge().GetMetrics()[key]; !ok || v == nil || (v.Unit == "" && v.Value == 0) {
 				result = false
 			}
 		}

--- a/internal/util/util_suite_test.go
+++ b/internal/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -63,6 +63,74 @@ var _ = Describe("Util", func() {
 				},
 			}
 
+			badGauge2 := &loggregator_v2.Envelope{
+				Timestamp: 1000000000,
+				SourceId: "app-id",
+				InstanceId: "4",
+				Tags: map[string]string{
+					"origin": "origin",
+					"deployment": "deployment-name",
+					"job": "doppler",
+				},
+				Message: &loggregator_v2.Envelope_Gauge{
+					Gauge: &loggregator_v2.Gauge{
+						Metrics: map[string]*loggregator_v2.GaugeValue{
+							"cpu": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(20.0),
+							},
+							"memory": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(19939949),
+							},
+							"disk": nil,
+							"memory_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(19939949),
+							},
+							"disk_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(29488929),
+							},
+						},
+					},
+				},
+			}
+
+			badGauge3 := &loggregator_v2.Envelope{
+				Timestamp: 1000000000,
+				SourceId: "app-id",
+				InstanceId: "4",
+				Tags: map[string]string{
+					"origin": "origin",
+					"deployment": "deployment-name",
+					"job": "doppler",
+				},
+				Message: &loggregator_v2.Envelope_Gauge{
+					Gauge: &loggregator_v2.Gauge{
+						Metrics: map[string]*loggregator_v2.GaugeValue{
+							"cpu": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(20.0),
+							},
+							"memory": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(19939949),
+							},
+							"disk": &loggregator_v2.GaugeValue{},
+							"memory_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(19939949),
+							},
+							"disk_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(29488929),
+							},
+						},
+					},
+				},
+			}
+
 			goodGauge := &loggregator_v2.Envelope{
 				Timestamp: 1000000000,
 				SourceId: "app-id",
@@ -102,6 +170,8 @@ var _ = Describe("Util", func() {
 
 			Expect(IsContainerMetric(counter)).To(BeFalse())
 			Expect(IsContainerMetric(badGauge)).To(BeFalse())
+			Expect(IsContainerMetric(badGauge2)).To(BeFalse())
+			Expect(IsContainerMetric(badGauge3)).To(BeFalse())
 			Expect(IsContainerMetric(goodGauge)).To(BeTrue())
 		})
 	})

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,108 @@
+package util
+
+import (
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Util", func() {
+	Context("IsContainerMetric", func() {
+		It("correctly identifies a container metric", func() {
+			counter := &loggregator_v2.Envelope{
+				Timestamp: 1000000000,
+				Tags: map[string]string{
+					"origin": "origin",
+					"deployment": "deployment-name",
+					"job": "doppler",
+				},
+				Message: &loggregator_v2.Envelope_Gauge{
+					Gauge: &loggregator_v2.Gauge{
+						Metrics: map[string]*loggregator_v2.GaugeValue{
+							"valueName": &loggregator_v2.GaugeValue{
+								Unit: "counter",
+								Value: float64(5),
+							},
+						},
+					},
+				},
+			}
+
+			badGauge := &loggregator_v2.Envelope{
+				Timestamp: 1000000000,
+				SourceId: "app-id",
+				InstanceId: "4",
+				Tags: map[string]string{
+					"origin": "origin",
+					"deployment": "deployment-name",
+					"job": "doppler",
+				},
+				Message: &loggregator_v2.Envelope_Gauge{
+					Gauge: &loggregator_v2.Gauge{
+						Metrics: map[string]*loggregator_v2.GaugeValue{
+							"cpu": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(20.0),
+							},
+							"memory": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(19939949),
+							},
+							// missing disk
+							"memory_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(19939949),
+							},
+							"disk_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(29488929),
+							},
+						},
+					},
+				},
+			}
+
+			goodGauge := &loggregator_v2.Envelope{
+				Timestamp: 1000000000,
+				SourceId: "app-id",
+				InstanceId: "4",
+				Tags: map[string]string{
+					"origin": "origin",
+					"deployment": "deployment-name",
+					"job": "doppler",
+				},
+				Message: &loggregator_v2.Envelope_Gauge{
+					Gauge: &loggregator_v2.Gauge{
+						Metrics: map[string]*loggregator_v2.GaugeValue{
+							"cpu": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(20.0),
+							},
+							"memory": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(19939949),
+							},
+							"disk": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(29488929),
+							},
+							"memory_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(19939949),
+							},
+							"disk_quota": &loggregator_v2.GaugeValue{
+								Unit: "gauge",
+								Value: float64(29488929),
+							},
+						},
+					},
+				},
+			}
+
+			Expect(IsContainerMetric(counter)).To(BeFalse())
+			Expect(IsContainerMetric(badGauge)).To(BeFalse())
+			Expect(IsContainerMetric(goodGauge)).To(BeTrue())
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 		config.InsecureSSLSkipVerify,
 		log,
 	)
+
 	threadDumpChan := registerGoRoutineDumpSignalChannel()
 	defer close(threadDumpChan)
 	go dumpGoRoutine(threadDumpChan)
@@ -55,7 +56,10 @@ func main() {
 	// Initialize and start Nozzle
 	log.Infof("Targeting datadog API URL: %s \n", config.DataDogURL)
 	datadog_nozzle := nozzle.NewNozzle(config, tokenFetcher, log)
-	datadog_nozzle.Start()
+	err = datadog_nozzle.Start()
+	if err != nil {
+		log.Error(err.Error())
+	}
 }
 
 func registerGoRoutineDumpSignalChannel() chan os.Signal {

--- a/test/helper/fake_cloud_controller_api.go
+++ b/test/helper/fake_cloud_controller_api.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"sync"
 	"time"
-
-	"github.com/cloudfoundry/sonde-go/events"
 )
 
 // FakeCloudControllerAPI mocks a cloud controller
@@ -28,7 +26,6 @@ type FakeCloudControllerAPI struct {
 	lastAuthorization string
 	requested         bool
 
-	events       []events.Envelope
 	closeMessage []byte
 
 	// Used to make the controller slow to answer
@@ -79,6 +76,7 @@ func (f *FakeCloudControllerAPI) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 	f.lock.Unlock()
 
 	time.Sleep(f.RequestTime * time.Millisecond)
+	rw.Header().Set("Content-Type", "application/json")
 	f.writeResponse(rw, r)
 
 	f.lock.Lock()
@@ -3017,5 +3015,7 @@ func (f *FakeCloudControllerAPI) writeResponse(rw http.ResponseWriter, r *http.R
 			"access_token": "%s"
 		}
 		`, f.tokenType, f.accessToken)))
+	case "/v2/read":
+		http.Redirect(rw, r, "http://asdasdasd.com", http.StatusPermanentRedirect)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Makes datadog-firehose-nozzle get data from loggregator V2 API instead of V1 API.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
