### PR TITLE
Preserve host tag when splitting series

### DIFF
--- a/internal/client/datadog/formatter.go
+++ b/internal/client/datadog/formatter.go
@@ -103,6 +103,7 @@ func splitPoints(data map[metric.MetricKey]metric.MetricValue) (a, b map[metric.
 			a[k] = metric.MetricValue{
 				Tags:   v.Tags,
 				Points: v.Points,
+				Host:   v.Host,
 			}
 			continue
 		}
@@ -110,10 +111,12 @@ func splitPoints(data map[metric.MetricKey]metric.MetricValue) (a, b map[metric.
 		a[k] = metric.MetricValue{
 			Tags:   v.Tags,
 			Points: v.Points[:split],
+			Host:   v.Host,
 		}
 		b[k] = metric.MetricValue{
 			Tags:   v.Tags,
 			Points: v.Points[split:],
+			Host:   v.Host,
 		}
 	}
 	return a, b

--- a/internal/client/datadog/formatter_test.go
+++ b/internal/client/datadog/formatter_test.go
@@ -1,12 +1,14 @@
 package datadog
 
 import (
+	"encoding/json"
+	"math"
+
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
 	"github.com/DataDog/datadog-firehose-nozzle/test/helper"
 	"github.com/cloudfoundry/gosteno"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"math"
 )
 
 var _ = Describe("Formatter", func() {
@@ -74,5 +76,65 @@ var _ = Describe("Formatter", func() {
 		result := formatter.Format("some-prefix", 1024, m)
 		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"metric":"bosh.healthmonitor.foo"`))
 		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"points":[[0,9.000000],[0,1.000000]]`))
+	})
+
+	It("properly assigns all values to split results when splitting", func() {
+		// first test a scenario where we're not splitting as there's just one point
+		m := make(map[metric.MetricKey]metric.MetricValue)
+		m[metric.MetricKey{Name: "a"}] = metric.MetricValue{
+			Points: []metric.Point{{Value: 9}},
+			Tags:   []string{"some:tag", "other:tag"},
+			Host:   "some.host",
+		}
+		result := formatter.Format("some-prefix.", 1, m)
+
+		Expect(result).To(HaveLen(1))
+
+		decompressed := helper.Decompress(result[0])
+		payload := Payload{}
+		err := json.Unmarshal(decompressed, &payload)
+		Expect(err).To(BeNil())
+		Expect(payload.Series).To(HaveLen(1))
+		s := payload.Series[0]
+		Expect(s.Metric).To(Equal("some-prefix.a"))
+		Expect(s.Points).To(Equal([]metric.Point{{Value: 9}}))
+		Expect(s.Type).To(Equal("gauge"))
+		Expect(s.Host).To(Equal("some.host"))
+		Expect(s.Tags).To(Equal([]string{"some:tag", "other:tag"}))
+
+		// now test a scenario where we're actually splitting points
+		m = make(map[metric.MetricKey]metric.MetricValue)
+		m[metric.MetricKey{Name: "a"}] = metric.MetricValue{
+			Points: []metric.Point{{Value: 9}, {Value: 10}},
+			Tags:   []string{"some:tag", "other:tag"},
+			Host:   "some.host",
+		}
+		result = formatter.Format("some-prefix.", 1, m)
+
+		Expect(result).To(HaveLen(2))
+
+		decompressed1 := helper.Decompress(result[0])
+		payload1 := Payload{}
+		err1 := json.Unmarshal(decompressed1, &payload1)
+		Expect(err1).To(BeNil())
+		Expect(payload1.Series).To(HaveLen(1))
+		s1 := payload1.Series[0]
+		Expect(s1.Metric).To(Equal("some-prefix.a"))
+		Expect(s1.Points).To(Equal([]metric.Point{{Value: 9}}))
+		Expect(s1.Type).To(Equal("gauge"))
+		Expect(s1.Host).To(Equal("some.host"))
+		Expect(s1.Tags).To(Equal([]string{"some:tag", "other:tag"}))
+
+		decompressed2 := helper.Decompress(result[1])
+		payload2 := Payload{}
+		err2 := json.Unmarshal(decompressed2, &payload2)
+		Expect(err2).To(BeNil())
+		Expect(payload2.Series).To(HaveLen(1))
+		s2 := payload2.Series[0]
+		Expect(s2.Metric).To(Equal("some-prefix.a"))
+		Expect(s2.Points).To(Equal([]metric.Point{{Value: 10}}))
+		Expect(s2.Type).To(Equal("gauge"))
+		Expect(s2.Host).To(Equal("some.host"))
+		Expect(s2.Tags).To(Equal([]string{"some:tag", "other:tag"}))
 	})
 })


### PR DESCRIPTION
### What does this PR do?

Makes sure we preserve `host` on submitted metrics when the payload is too large and we have to split it.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
