### PR TITLE
changelog/Fixed: Add Token Refresh Logic to V2 Firehose Client Wrapper

### DIFF
--- a/internal/nozzle/nozzle.go
+++ b/internal/nozzle/nozzle.go
@@ -63,12 +63,6 @@ func NewNozzle(config *config.Config, tokenFetcher AuthTokenFetcher, log *gosten
 func (n *Nozzle) Start() error {
 	n.log.Info("Starting DataDog Firehose Nozzle...")
 
-	// Fetch Authentication Token
-	var authToken string
-	if !n.config.DisableAccessControl {
-		authToken = n.authTokenFetcher.FetchAuthToken()
-	}
-
 	// Fetch Custom Tags
 	if n.config.CustomTags == nil {
 		n.config.CustomTags = []string{}
@@ -113,7 +107,7 @@ func (n *Nozzle) Start() error {
 	}
 
 	// Initialize the firehose consumer (with retry enable)
-	err = n.startFirehoseConsumer(authToken)
+	err = n.startFirehoseConsumer(n.authTokenFetcher)
 	if err != nil {
 		return err
 	}
@@ -143,9 +137,9 @@ func (n *Nozzle) Start() error {
 	return err
 }
 
-func (n *Nozzle) startFirehoseConsumer(authToken string) error {
+func (n *Nozzle) startFirehoseConsumer(authTokenFetcher AuthTokenFetcher) error {
 	var err error
-	n.loggregatorClient, err = cloudfoundry.NewLoggregatorClient(n.config, n.log, authToken)
+	n.loggregatorClient, err = cloudfoundry.NewLoggregatorClient(n.config, n.log, authTokenFetcher)
 	if err != nil {
 		return err
 	}

--- a/test/helper/fake_uaa.go
+++ b/test/helper/fake_uaa.go
@@ -14,7 +14,7 @@ type FakeUAA struct {
 	tokenType   string
 	accessToken string
 
-	requested bool
+	timesRequested int
 }
 
 func NewFakeUAA(tokenType string, accessToken string) *FakeUAA {
@@ -40,7 +40,13 @@ func (f *FakeUAA) URL() string {
 func (f *FakeUAA) Requested() bool {
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	return f.requested
+	return f.timesRequested > 0
+}
+
+func (f *FakeUAA) TimesRequested() int {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	return f.timesRequested
 }
 
 func (f *FakeUAA) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
@@ -52,7 +58,7 @@ func (f *FakeUAA) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		}
 	`, f.tokenType, f.accessToken)))
 	f.lock.Lock()
-	f.requested = true
+	f.timesRequested++
 	f.lock.Unlock()
 }
 


### PR DESCRIPTION
Signed-off-by: Rachel Heaton <rheaton@pivotal.io>

### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

When the datadog firehose nozzle changed to consuming from firehose v2 client, it required additional logic to handle the case where the client's auth token expires. The v1 firehose client had an automatic token refresher that handled this case. Currently, the nozzle will start and stop working once the auth token it acquired when it started up expires (defaults to 14 days).

### Description of the Change

Added logic for datadog nozzle firehose client wrapper to detect when it gets an unauthorized response from Firehose V2 and makes a second attempt with a new auth token.

#### What process did you follow to verify that your change has the desired effects?

* How did you verify that all new functionality works as expected?
** A test was added

* How did you verify that all changed functionality works as expected?
** Via the test

* How did you verify that the change has not introduced any regressions?
** Verified that all existing tests still passed

### Additional Notes


### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [X] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [X] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [X] PR should not have `do-not-merge/` label attached.
- [X] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
