### PR TITLE
Token Refresh for RLP Client Needs to Handle 404

### DIFF
--- a/internal/client/cloudfoundry/loggregator_client.go
+++ b/internal/client/cloudfoundry/loggregator_client.go
@@ -52,7 +52,7 @@ func (d *rlpGatewayClientDoer) Do(req *http.Request) (*http.Response, error) {
 		return resp, err
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+	if resp.StatusCode >= http.StatusBadRequest {
 		time.Sleep(100 * time.Millisecond)
 		d.token = d.tokenFetcher.FetchAuthToken()
 


### PR DESCRIPTION
Signed-off-by: Ben Fuller <bfuller@pivotal.io>

### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

When the datadog firehose nozzle changed to consuming from firehose v2 client, it required additional logic to handle the case where the client's auth token expires. The v1 firehose client had an automatic token refresher that handled this case. Currently, the nozzle will start and stop working once the auth token it acquired when it started up expires (defaults to 14 days). The refresh logic needs to also happen when RLP returns a 404.

### Description of the Change

Updated token refresh logic to handle RLP returning a 404

#### What process did you follow to verify that your change has the desired effects?

* How did you verify that all new functionality works as expected?
** A test was added

* How did you verify that all changed functionality works as expected?
** Via the test

* How did you verify that the change has not introduced any regressions?
** Verified that all existing tests still passed

### Additional Notes


### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [X] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [X] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [X] PR should not have `do-not-merge/` label attached.
- [X] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
