### PR TITLE
Improve metric submission logic to split metric packets

### DIFF
--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -3,6 +3,7 @@ package datadog
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -351,17 +352,15 @@ var _ = Describe("DatadogClient", func() {
 
 	It("breaks up a message that exceeds the FlushMaxBytes", func() {
 		for i := 0; i < 1000; i++ {
-			k, v := makeFakeMetric("metricName", 1000, uint64(i), defaultTags)
+			k, v := makeFakeMetric(fmt.Sprintf("metricName_%v", i), 1000, 1, defaultTags)
 			metricsMap.Add(k, v)
 		}
-
 		err := c.PostMetrics(metricsMap)
 		Expect(err).ToNot(HaveOccurred())
 
 		f := func() int {
 			return len(bodies)
 		}
-
 		Eventually(f).Should(BeNumerically(">", 1))
 	})
 

--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -362,7 +362,7 @@ var _ = Describe("DatadogClient", func() {
 			return len(bodies)
 		}
 
-		Eventually(f).Should(BeNumerically("==", 0))
+		Eventually(f).Should(BeNumerically(">", 1))
 	})
 
 	It("discards metrics that exceed that max size", func() {

--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -362,7 +362,7 @@ var _ = Describe("DatadogClient", func() {
 			return len(bodies)
 		}
 
-		Eventually(f).Should(BeNumerically(">", 1))
+		Eventually(f).Should(BeNumerically("==", 0))
 	})
 
 	It("discards metrics that exceed that max size", func() {

--- a/internal/client/datadog/client_test.go
+++ b/internal/client/datadog/client_test.go
@@ -357,7 +357,6 @@ var _ = Describe("DatadogClient", func() {
 		}
 		err := c.PostMetrics(metricsMap)
 		Expect(err).ToNot(HaveOccurred())
-
 		f := func() int {
 			return len(bodies)
 		}

--- a/internal/client/datadog/formatter.go
+++ b/internal/client/datadog/formatter.go
@@ -30,6 +30,10 @@ func (f Formatter) Format(prefix string, maxPostBytes uint32, data map[metric.Me
 
 	if uint32(len(compressedSeriesBytes)) > maxPostBytes {
 		if len(data) == 1 {
+			for k, _ := range data {
+				f.log.Warn(fmt.Sprintf("Warning dropping metric payload: %v", k.Name))
+			}
+
 			return nil
 		}
 
@@ -95,7 +99,7 @@ func splitMetrics(data map[metric.MetricKey]metric.MetricValue) (a, b map[metric
 	b = make(map[metric.MetricKey]metric.MetricValue)
 
 	for k, v := range data {
-		if len(a) <= len(data)/2 {
+		if len(a) < len(data)/2 {
 			a[k] = v
 		} else {
 			b[k] = v

--- a/internal/client/datadog/formatter.go
+++ b/internal/client/datadog/formatter.go
@@ -27,8 +27,14 @@ func (f Formatter) Format(prefix string, maxPostBytes uint32, data map[metric.Me
 		f.log.Errorf("Error formatting metrics payload: %v", err)
 		return result
 	}
-	if uint32(len(compressedSeriesBytes)) > maxPostBytes && len(data) > 1 {
+
+	if uint32(len(compressedSeriesBytes)) > maxPostBytes {
+		if len(data) == 1 {
+			return nil
+		}
+
 		metricsA, metricsB := splitMetrics(data)
+
 		result = append(result, f.Format(prefix, maxPostBytes, metricsA)...)
 		result = append(result, f.Format(prefix, maxPostBytes, metricsB)...)
 

--- a/internal/client/datadog/formatter.go
+++ b/internal/client/datadog/formatter.go
@@ -27,8 +27,8 @@ func (f Formatter) Format(prefix string, maxPostBytes uint32, data map[metric.Me
 		f.log.Errorf("Error formatting metrics payload: %v", err)
 		return result
 	}
-	if uint32(len(compressedSeriesBytes)) > maxPostBytes && canSplit(data) {
-		metricsA, metricsB := splitPoints(data)
+	if uint32(len(compressedSeriesBytes)) > maxPostBytes && len(data) > 1 {
+		metricsA, metricsB := splitMetrics(data)
 		result = append(result, f.Format(prefix, maxPostBytes, metricsA)...)
 		result = append(result, f.Format(prefix, maxPostBytes, metricsB)...)
 
@@ -84,39 +84,15 @@ func (f Formatter) removeNANs(points []metric.Point, metricName string, tags []s
 
 }
 
-func canSplit(data map[metric.MetricKey]metric.MetricValue) bool {
-	for _, v := range data {
-		if len(v.Points) > 1 {
-			return true
-		}
-	}
-
-	return false
-}
-
-func splitPoints(data map[metric.MetricKey]metric.MetricValue) (a, b map[metric.MetricKey]metric.MetricValue) {
+func splitMetrics(data map[metric.MetricKey]metric.MetricValue) (a, b map[metric.MetricKey]metric.MetricValue) {
 	a = make(map[metric.MetricKey]metric.MetricValue)
 	b = make(map[metric.MetricKey]metric.MetricValue)
-	for k, v := range data {
-		split := len(v.Points) / 2
-		if split == 0 {
-			a[k] = metric.MetricValue{
-				Tags:   v.Tags,
-				Points: v.Points,
-				Host:   v.Host,
-			}
-			continue
-		}
 
-		a[k] = metric.MetricValue{
-			Tags:   v.Tags,
-			Points: v.Points[:split],
-			Host:   v.Host,
-		}
-		b[k] = metric.MetricValue{
-			Tags:   v.Tags,
-			Points: v.Points[split:],
-			Host:   v.Host,
+	for k, v := range data {
+		if len(a) <= len(data)/2 {
+			a[k] = v
+		} else {
+			b[k] = v
 		}
 	}
 	return a, b

--- a/internal/client/datadog/formatter_test.go
+++ b/internal/client/datadog/formatter_test.go
@@ -1,6 +1,7 @@
 package datadog
 
 import (
+	"encoding/json"
 	"math"
 
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
@@ -12,11 +13,13 @@ import (
 
 var _ = Describe("Formatter", func() {
 	var (
-		formatter Formatter
+		formatter  Formatter
+		metricsMap metric.MetricsMap
 	)
 
 	BeforeEach(func() {
 		formatter = Formatter{gosteno.NewLogger("test")}
+		metricsMap = make(metric.MetricsMap)
 	})
 
 	It("does not return empty data", func() {
@@ -75,5 +78,41 @@ var _ = Describe("Formatter", func() {
 		result := formatter.Format("some-prefix", 1024, m)
 		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"metric":"bosh.healthmonitor.foo"`))
 		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"points":[[0,9.000000],[0,1.000000]]`))
+	})
+
+	It("properly assigns all values to split results when splitting", func() {
+		// first test a scenario where we're not splitting as there's just one point
+		m := make(map[metric.MetricKey]metric.MetricValue)
+		m[metric.MetricKey{Name: "a"}] = metric.MetricValue{
+			Points: []metric.Point{{Value: 9}},
+			Tags:   []string{"some:tag", "other:tag"},
+			Host:   "some.host",
+		}
+		result := formatter.Format("some-prefix.", 1, m)
+
+		Expect(result).To(HaveLen(1))
+
+		decompressed := helper.Decompress(result[0])
+		payload := Payload{}
+		err := json.Unmarshal(decompressed, &payload)
+		Expect(err).To(BeNil())
+		Expect(payload.Series).To(HaveLen(1))
+		s := payload.Series[0]
+		Expect(s.Metric).To(Equal("some-prefix.a"))
+		Expect(s.Points).To(Equal([]metric.Point{{Value: 9}}))
+		Expect(s.Type).To(Equal("gauge"))
+		Expect(s.Host).To(Equal("some.host"))
+		Expect(s.Tags).To(Equal([]string{"some:tag", "other:tag"}))
+
+		// now test a scenario where we're actually splitting metrics
+		for i := 0; i < 1000; i++ {
+			k, v := makeFakeMetric("metricName", 1000, uint64(i), defaultTags)
+			metricsMap.Add(k, v)
+		}
+
+		a, b := splitMetrics(metricsMap)
+
+		Expect(len(a)).To(BeNumerically("<=", len(metricsMap)))
+		Expect(len(b)).To(BeNumerically("<=", len(metricsMap)))
 	})
 })

--- a/internal/client/datadog/formatter_test.go
+++ b/internal/client/datadog/formatter_test.go
@@ -1,7 +1,6 @@
 package datadog
 
 import (
-	"encoding/json"
 	"math"
 
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
@@ -76,65 +75,5 @@ var _ = Describe("Formatter", func() {
 		result := formatter.Format("some-prefix", 1024, m)
 		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"metric":"bosh.healthmonitor.foo"`))
 		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"points":[[0,9.000000],[0,1.000000]]`))
-	})
-
-	It("properly assigns all values to split results when splitting", func() {
-		// first test a scenario where we're not splitting as there's just one point
-		m := make(map[metric.MetricKey]metric.MetricValue)
-		m[metric.MetricKey{Name: "a"}] = metric.MetricValue{
-			Points: []metric.Point{{Value: 9}},
-			Tags:   []string{"some:tag", "other:tag"},
-			Host:   "some.host",
-		}
-		result := formatter.Format("some-prefix.", 1, m)
-
-		Expect(result).To(HaveLen(1))
-
-		decompressed := helper.Decompress(result[0])
-		payload := Payload{}
-		err := json.Unmarshal(decompressed, &payload)
-		Expect(err).To(BeNil())
-		Expect(payload.Series).To(HaveLen(1))
-		s := payload.Series[0]
-		Expect(s.Metric).To(Equal("some-prefix.a"))
-		Expect(s.Points).To(Equal([]metric.Point{{Value: 9}}))
-		Expect(s.Type).To(Equal("gauge"))
-		Expect(s.Host).To(Equal("some.host"))
-		Expect(s.Tags).To(Equal([]string{"some:tag", "other:tag"}))
-
-		// now test a scenario where we're actually splitting points
-		m = make(map[metric.MetricKey]metric.MetricValue)
-		m[metric.MetricKey{Name: "a"}] = metric.MetricValue{
-			Points: []metric.Point{{Value: 9}, {Value: 10}},
-			Tags:   []string{"some:tag", "other:tag"},
-			Host:   "some.host",
-		}
-		result = formatter.Format("some-prefix.", 1, m)
-
-		Expect(result).To(HaveLen(2))
-
-		decompressed1 := helper.Decompress(result[0])
-		payload1 := Payload{}
-		err1 := json.Unmarshal(decompressed1, &payload1)
-		Expect(err1).To(BeNil())
-		Expect(payload1.Series).To(HaveLen(1))
-		s1 := payload1.Series[0]
-		Expect(s1.Metric).To(Equal("some-prefix.a"))
-		Expect(s1.Points).To(Equal([]metric.Point{{Value: 9}}))
-		Expect(s1.Type).To(Equal("gauge"))
-		Expect(s1.Host).To(Equal("some.host"))
-		Expect(s1.Tags).To(Equal([]string{"some:tag", "other:tag"}))
-
-		decompressed2 := helper.Decompress(result[1])
-		payload2 := Payload{}
-		err2 := json.Unmarshal(decompressed2, &payload2)
-		Expect(err2).To(BeNil())
-		Expect(payload2.Series).To(HaveLen(1))
-		s2 := payload2.Series[0]
-		Expect(s2.Metric).To(Equal("some-prefix.a"))
-		Expect(s2.Points).To(Equal([]metric.Point{{Value: 10}}))
-		Expect(s2.Type).To(Equal("gauge"))
-		Expect(s2.Host).To(Equal("some.host"))
-		Expect(s2.Tags).To(Equal([]string{"some:tag", "other:tag"}))
 	})
 })

--- a/internal/client/datadog/formatter_test.go
+++ b/internal/client/datadog/formatter_test.go
@@ -1,6 +1,7 @@
 package datadog
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
@@ -80,16 +81,14 @@ var _ = Describe("Formatter", func() {
 	})
 
 	It("properly splits metrics into two maps", func() {
-		// now test a scenario where we're actually splitting metrics
 		for i := 0; i < 1000; i++ {
-			k, v := makeFakeMetric("metricName", 1000, uint64(i), defaultTags)
+			k, v := makeFakeMetric(fmt.Sprintf("metricName_%v", i), 1000, 1, defaultTags)
 			metricsMap.Add(k, v)
 		}
 
 		a, b := splitMetrics(metricsMap)
 
-		Expect(len(a) + len(b)).To(Equal(len(metricsMap)))
-		Expect(len(a)).To(Equal(len(metricsMap) - len(metricsMap)/2))
-		Expect(len(b)).To(Equal(len(metricsMap) / 2))
+		Expect(len(a)).To(Equal(500))
+		Expect(len(b)).To(Equal(500))
 	})
 })

--- a/internal/client/datadog/formatter_test.go
+++ b/internal/client/datadog/formatter_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Formatter", func() {
 		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"points":[[0,9.000000],[0,1.000000]]`))
 	})
 
-	It("properly split metrics into two maps", func() {
+	It("properly splits metrics into two maps", func() {
 		// first test a scenario where we're not splitting as there's just one point
 		m := make(map[metric.MetricKey]metric.MetricValue)
 		m[metric.MetricKey{Name: "a"}] = metric.MetricValue{

--- a/internal/client/datadog/formatter_test.go
+++ b/internal/client/datadog/formatter_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Formatter", func() {
 		Expect(string(helper.Decompress(result[0]))).To(ContainSubstring(`"points":[[0,9.000000],[0,1.000000]]`))
 	})
 
-	It("properly assigns all values to split results when splitting", func() {
+	It("properly split metrics into two maps", func() {
 		// first test a scenario where we're not splitting as there's just one point
 		m := make(map[metric.MetricKey]metric.MetricValue)
 		m[metric.MetricKey{Name: "a"}] = metric.MetricValue{

--- a/internal/client/datadog/formatter_test.go
+++ b/internal/client/datadog/formatter_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Formatter", func() {
 		Expect(string(helper.Decompress(result[0]))).To(Equal(`{"series":[{"metric":"foobar","points":[[0,9.000000]],"type":"gauge"}]}`))
 	})
 
-	It("does not 'delete' points when trying to split", func() {
+	It("drops metrics that are larger than maxPostBytes", func() {
 		m := make(map[metric.MetricKey]metric.MetricValue)
 		m[metric.MetricKey{Name: "a"}] = metric.MetricValue{
 			Points: []metric.Point{{
@@ -46,7 +46,7 @@ var _ = Describe("Formatter", func() {
 		}
 		result := formatter.Format("some-prefix", 1, m)
 
-		Expect(result).To(HaveLen(1))
+		Expect(result).To(HaveLen(0))
 	})
 
 	It("does not prepend prefix to `bosh.healthmonitor`", func() {


### PR DESCRIPTION
### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Related issue: https://datadoghq.atlassian.net/browse/ITL-659
### Description of the Change

Change the splitting logic for the packets, instead of splitting metrics that have multiple points, we just split the packets in a way to fit the `maxPostBytes`.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
