### PR TITLE
Fix sidecars tagging

### DIFF
--- a/internal/client/cloudfoundry/client.go
+++ b/internal/client/cloudfoundry/client.go
@@ -618,7 +618,7 @@ func (cfc *CFClient) GetV2OrgQuotas() ([]CFOrgQuota, error) {
 
 func (cfc *CFClient) getCFSidecars(appGUID string) ([]CFSidecar, error) {
 	query := url.Values{}
-	query.Set("results-per-page", "100")
+	query.Set("per_page", "100")
 
 	var sidecars []CFSidecar
 

--- a/internal/processor/parser/app_test.go
+++ b/internal/processor/parser/app_test.go
@@ -51,6 +51,7 @@ var _ = Describe("AppMetrics", func() {
 			DCAUrl:                  dcaAPIURL,
 			DCAToken:                "123456789",
 			DCAEnabled:              true,
+			EnableAdvancedTagging:   true,
 		}
 		var err error
 		fakeCfClient, err = cloudfoundry.NewClient(&cfg, log)
@@ -250,96 +251,11 @@ var _ = Describe("AppMetrics", func() {
 				Expect(metric.MetricValue.Tags).To(ContainElement("annotation/org-annotation:org-annotation-value"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("auto-annotation-tag:auto-annotation-tag-value"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("auto-label-tag:auto-label-tag-value"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("sidecar_present:true"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("sidecar_count:1"))
 				Expect(metric.MetricValue.Tags).ToNot(ContainElement("annotation/blacklisted_key:foo"))
 				Expect(metric.MetricValue.Tags).ToNot(ContainElement("label/blacklisted_key:bar"))
-			}
-		})
 
-		It("parses an event properly and adds metadata if configured using cloud foundry client", func() {
-			config.NozzleConfig.EnableMetadataCollection = true
-			config.NozzleConfig.MetadataKeysBlacklist = []*regexp.Regexp{regexp.MustCompile("blacklisted.*")}
-			a, err := NewAppParser(fakeCfClient, nil, 5, 10, log, []string{}, "env_name")
-			Expect(err).To(BeNil())
-			Eventually(a.AppCache.IsWarmedUp).Should(BeTrue())
-
-			event := &loggregator_v2.Envelope{
-				Timestamp:  1000000000,
-				SourceId:   "6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a",
-				InstanceId: "4",
-				Tags: map[string]string{
-					"origin":     "test-origin",
-					"deployment": "deployment-name",
-					"job":        "doppler",
-					"index":      "1",
-					"ip":         "10.0.1.2",
-				},
-				Message: &loggregator_v2.Envelope_Gauge{
-					Gauge: &loggregator_v2.Gauge{
-						Metrics: map[string]*loggregator_v2.GaugeValue{
-							"cpu": {
-								Unit:  "gauge",
-								Value: float64(1),
-							},
-							"memory": {
-								Unit:  "gauge",
-								Value: float64(1),
-							},
-							"disk": {
-								Unit:  "gauge",
-								Value: float64(1),
-							},
-							"memory_quota": {
-								Unit:  "gauge",
-								Value: float64(1),
-							},
-							"disk_quota": {
-								Unit:  "gauge",
-								Value: float64(1),
-							},
-						},
-					},
-				},
-			}
-
-			metrics, err := a.Parse(event)
-
-			Expect(err).To(BeNil())
-			Expect(metrics).To(HaveLen(10))
-
-			Expect(metrics).To(ContainMetric("app.disk.configured"))
-			Expect(metrics).To(ContainMetric("app.disk.provisioned"))
-			Expect(metrics).To(ContainMetric("app.memory.configured"))
-			Expect(metrics).To(ContainMetric("app.memory.provisioned"))
-			Expect(metrics).To(ContainMetric("app.instances"))
-			Expect(metrics).To(ContainMetric("app.cpu.pct"))
-			Expect(metrics).To(ContainMetric("app.disk.used"))
-			Expect(metrics).To(ContainMetric("app.disk.quota"))
-			Expect(metrics).To(ContainMetric("app.memory.used"))
-			Expect(metrics).To(ContainMetric("app.memory.quota"))
-
-			for _, metric := range metrics {
-				Expect(metric.MetricValue.Tags).To(ContainElement("app_name:hello-datadog-cf-ruby-dev"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("guid:6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("env:env_name"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("source_id:6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("label/app-space-org-label:app-space-org-label-app-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("label/app-space-label:app-space-label-app-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("label/app-org-label:app-org-label-app-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("label/app-label:app-label-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("label/space-org-label:space-org-label-space-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("label/space-label:space-label-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("label/org-label:org-label-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("annotation/app-space-org-annotation:app-space-org-annotation-app-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("annotation/app-space-annotation:app-space-annotation-app-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("annotation/app-org-annotation:app-org-annotation-app-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("annotation/app-annotation:app-annotation-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("annotation/space-org-annotation:space-org-annotation-space-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("annotation/space-annotation:space-annotation-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("annotation/org-annotation:org-annotation-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("auto-annotation-tag:auto-annotation-tag-value"))
-				Expect(metric.MetricValue.Tags).To(ContainElement("auto-label-tag:auto-label-tag-value"))
-				Expect(metric.MetricValue.Tags).ToNot(ContainElement("annotation/blacklisted_key:foo"))
-				Expect(metric.MetricValue.Tags).ToNot(ContainElement("label/blacklisted_key:bar"))
 			}
 		})
 

--- a/internal/processor/parser/app_test.go
+++ b/internal/processor/parser/app_test.go
@@ -336,6 +336,8 @@ var _ = Describe("AppMetrics", func() {
 				Expect(metric.MetricValue.Tags).To(ContainElement("annotation/app-annotation:app-annotation-value"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("auto-annotation-tag:auto-annotation-tag-value"))
 				Expect(metric.MetricValue.Tags).To(ContainElement("auto-label-tag:auto-label-tag-value"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("sidecar_present:true"))
+				Expect(metric.MetricValue.Tags).To(ContainElement("sidecar_count:1"))
 				Expect(metric.MetricValue.Tags).ToNot(ContainElement("annotation/blacklisted_key:foo"))
 				Expect(metric.MetricValue.Tags).ToNot(ContainElement("label/blacklisted_key:bar"))
 			}

--- a/test/helper/fake_cloud_controller_api.go
+++ b/test/helper/fake_cloud_controller_api.go
@@ -3129,10 +3129,10 @@ func (f *FakeCloudControllerAPI) writeResponse(rw http.ResponseWriter, r *http.R
 				   "total_results": 1,
 				   "total_pages": 1,
 				   "first": {
-					  "href": "https://api.sys.integrations-lab.devenv.dog/v3/apps/a7ddcd5e-bdf0-44b5-8473-df6fcccd9dc4/sidecars?page=1&per_page=50"
+					  "href": "https://api.sys.integrations-lab.devenv.dog/v3/apps/6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a/sidecars?page=1&per_page=50"
 				   },
 				   "last": {
-					  "href": "https://api.sys.integrations-lab.devenv.dog/v3/apps/a7ddcd5e-bdf0-44b5-8473-df6fcccd9dc4/sidecars?page=1&per_page=50"
+					  "href": "https://api.sys.integrations-lab.devenv.dog/v3/apps/6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a/sidecars?page=1&per_page=50"
 				   },
 				   "next": null,
 				   "previous": null
@@ -3160,6 +3160,44 @@ func (f *FakeCloudControllerAPI) writeResponse(rw http.ResponseWriter, r *http.R
 				]
 			 }
 			`))
+			} else if strings.Contains(r.URL.Path, "6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a") {
+				rw.Write([]byte(`
+				{
+					"pagination": {
+					   "total_results": 1,
+					   "total_pages": 1,
+					   "first": {
+						  "href": "https://api.sys.integrations-lab.devenv.dog/v3/apps/6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a/sidecars?page=1&per_page=50"
+					   },
+					   "last": {
+						  "href": "https://api.sys.integrations-lab.devenv.dog/v3/apps/6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a/sidecars?page=1&per_page=50"
+					   },
+					   "next": null,
+					   "previous": null
+					},
+					"resources": [
+					   {
+						  "guid": "sidecar_guid",
+						  "name": "sidecar_name",
+						  "command": "sidecar_command",
+						  "process_types": [
+							 "process_type_1"
+						  ],
+						  "memory_in_mb": null,
+						  "origin": "user",
+						  "relationships": {
+							 "app": {
+								"data": {
+								   "guid": "6116f9ec-2bd6-4dd6-b7fe-a1b6acf6662a"
+								}
+							 }
+						  },
+						  "created_at": "2022-03-17T09:57:48Z",
+						  "updated_at": "2022-03-17T09:57:48Z"
+					   }
+					]
+				 }
+				`))
 			} else {
 				rw.Write([]byte(`
 				{

--- a/test/helper/fake_cluster_agent_api.go
+++ b/test/helper/fake_cluster_agent_api.go
@@ -178,7 +178,12 @@ func (f *FakeClusterAgentAPI) writeResponse(rw http.ResponseWriter, r *http.Requ
 				"blacklisted_key": "bar",
 				"tags.datadoghq.com/auto-annotation-tag": "auto-annotation-tag-value"
 			},
-			"Sidecars": null
+			"Sidecars": [
+				{
+					"Name": "sidecar-name-2",
+					"GUID": "sidecar-guid-2"
+				}
+			]
 		}, {
 			"GUID": "9d519c2b-261e-4553-9db3-c79c8a9857f5",
 			"Name": "test_log_redirect",


### PR DESCRIPTION
Fixes wrong query parameter `result-per-page`, should have been `per_page` and increase unit tests for sidecars tags.