### PR TITLE
Add support for logs and traces correlation

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -188,7 +188,7 @@ func (p *Processor) ProcessLog(envelope *loggregator_v2.Envelope) {
 	if source == "" {
 		if job, ok := envelope.GetTags()["job"]; ok {
 			source = job
-		} else if source == "" {
+		} else {
 			source = "datadog-firehose-nozzle"
 		}
 	}

--- a/test/helper/fake_cloud_controller_api.go
+++ b/test/helper/fake_cloud_controller_api.go
@@ -1371,6 +1371,7 @@ func (f *FakeCloudControllerAPI) writeResponse(rw http.ResponseWriter, r *http.R
 										"tags.datadoghq.com/auto-annotation-tag": "auto-annotation-tag-value"
 									},
 									"labels": {
+										"tags.datadoghq.com/ddsource": "ddsource-label-value",
 										"app-label": "app-label-value",
 										"app-space-label": "app-space-label-app-value",
 										"app-org-label": "app-org-label-app-value",


### PR DESCRIPTION
### What does this PR do?

When submitting logs to Datadog, the `source` field must be correctly set for the backend to parse the logs metadata, such as the trace-id. 

More information about the source field can be found [here](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes).

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change

The nozzle will detect the `source` of the application logs based on the following (in order of priority):

1. App labels/annotations containing the key `tags.datadoghq.com/ddsource`.
2. App Buildpacks as specified by the CAPI.
3. Envelope `job` value. 
4. Else, set the source to `datadog-firehose-nozzle`.

We only support detecting the official [Cloud Foundry system buildpacks](https://docs.cloudfoundry.org/buildpacks/system-buildpacks.html) out of the box.

<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

- Added Unit tests
- Deployed the Nozzle on TAS 4.0 and TAS 5.0.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
