### PR TITLE
Add BOSH tags and hostname generation for CloudPrem logs

### DIFF
--- a/config/datadog-firehose-nozzle.json
+++ b/config/datadog-firehose-nozzle.json
@@ -23,5 +23,13 @@
   "AppMetrics": true,
   "NumWorkers": 1,
   "CustomTags": [],
-  "OrgDataCollectionInterval": 600
+  "OrgDataCollectionInterval": 600,
+
+  "BoshTagsConfig": {
+    "bosh_tags": false,
+    "friendly_hostname": true,
+    "unique_friendly_hostname": false,
+    "friendly_hostname_append_guid": false,
+    "use_uuid_hostname": false
+  }
 }

--- a/config/datadog-firehose-nozzle.json
+++ b/config/datadog-firehose-nozzle.json
@@ -26,10 +26,10 @@
   "OrgDataCollectionInterval": 600,
 
   "BoshTagsConfig": {
-    "bosh_tags": false,
-    "friendly_hostname": true,
-    "unique_friendly_hostname": false,
-    "friendly_hostname_append_guid": false,
-    "use_uuid_hostname": false
+    "BoshTags": false,
+    "FriendlyHostname": true,
+    "UniqueFriendlyHostname": false,
+    "FriendlyHostnameAppendGuid": false,
+    "UseUuidHostname": false
   }
 }

--- a/config/datadog-firehose-nozzle.json
+++ b/config/datadog-firehose-nozzle.json
@@ -26,7 +26,7 @@
   "OrgDataCollectionInterval": 600,
 
   "BoshTagsConfig": {
-    "BoshTags": false,
+    "Enabled": false,
     "FriendlyHostname": true,
     "UniqueFriendlyHostname": false,
     "FriendlyHostnameAppendGuid": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/DataDog/datadog-firehose-nozzle/internal/tags"
 )
 
 const (
@@ -68,6 +70,11 @@ type Config struct {
 	DCAEnabled                          bool
 	DCAUrl                              string
 	DCAToken                            string
+
+	// BOSH tag/hostname configuration for Datadog BYOC log solution (CloudPrem).
+	// When enabled, tags and hostname are generated from envelope metadata
+	// to replicate the Datadog SaaS behavior which enriches logs after ingestion.
+	BoshTagsConfig tags.BoshTagsConfig
 }
 
 // AsLogString returns a string representation of the config that is safe to log (no secrets)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -157,7 +157,9 @@ var _ = Describe("NozzleConfig", func() {
 
 	It("correctly serializes to log string", func() {
 		// For logs, we want this to be serialized as one long line without newlines
-		expected := `{"AppMetrics":true,"Client":"user","ClientSecret":"*****","CloudControllerAPIBatchSize":1000,`
+		expected := `{"AppMetrics":true,`
+		expected += `"BoshTagsConfig":{"bosh_tags":false,"friendly_hostname":false,"friendly_hostname_append_guid":false,"unique_friendly_hostname":false,"use_uuid_hostname":false},`
+		expected += `"Client":"user","ClientSecret":"*****","CloudControllerAPIBatchSize":1000,`
 		expected += `"CloudControllerEndpoint":"string","CustomTags":["nozzle:foobar","env:prod","role:db"],`
 		expected += `"DCAEnabled":true,"DCAToken":"123456789","DCAUrl":"datadog-cluster-agent.bosh-deployment-name:5005",`
 		expected += `"DataDogAPIKey":"*****","DataDogAdditionalEndpoints":{"https://app.datadoghq.com/api/v1/series":["*****","*****"],`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -158,7 +158,7 @@ var _ = Describe("NozzleConfig", func() {
 	It("correctly serializes to log string", func() {
 		// For logs, we want this to be serialized as one long line without newlines
 		expected := `{"AppMetrics":true,`
-		expected += `"BoshTagsConfig":{"BoshTags":false,"FriendlyHostname":false,"FriendlyHostnameAppendGuid":false,"UniqueFriendlyHostname":false,"UseUuidHostname":false},`
+		expected += `"BoshTagsConfig":{"Enabled":false,"FriendlyHostname":false,"FriendlyHostnameAppendGuid":false,"UniqueFriendlyHostname":false,"UseUuidHostname":false},`
 		expected += `"Client":"user","ClientSecret":"*****","CloudControllerAPIBatchSize":1000,`
 		expected += `"CloudControllerEndpoint":"string","CustomTags":["nozzle:foobar","env:prod","role:db"],`
 		expected += `"DCAEnabled":true,"DCAToken":"123456789","DCAUrl":"datadog-cluster-agent.bosh-deployment-name:5005",`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -158,7 +158,7 @@ var _ = Describe("NozzleConfig", func() {
 	It("correctly serializes to log string", func() {
 		// For logs, we want this to be serialized as one long line without newlines
 		expected := `{"AppMetrics":true,`
-		expected += `"BoshTagsConfig":{"bosh_tags":false,"friendly_hostname":false,"friendly_hostname_append_guid":false,"unique_friendly_hostname":false,"use_uuid_hostname":false},`
+		expected += `"BoshTagsConfig":{"BoshTags":false,"FriendlyHostname":false,"FriendlyHostnameAppendGuid":false,"UniqueFriendlyHostname":false,"UseUuidHostname":false},`
 		expected += `"Client":"user","ClientSecret":"*****","CloudControllerAPIBatchSize":1000,`
 		expected += `"CloudControllerEndpoint":"string","CustomTags":["nozzle:foobar","env:prod","role:db"],`
 		expected += `"DCAEnabled":true,"DCAToken":"123456789","DCAUrl":"datadog-cluster-agent.bosh-deployment-name:5005",`

--- a/internal/processor/parser/infra.go
+++ b/internal/processor/parser/infra.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-firehose-nozzle/internal/config"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/logs"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/metric"
+	"github.com/DataDog/datadog-firehose-nozzle/internal/tags"
 	"github.com/DataDog/datadog-firehose-nozzle/internal/util"
 
 	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
@@ -103,11 +105,21 @@ func (p InfraParser) ParseLog(envelope *loggregator_v2.Envelope) (logs.LogMessag
 	}
 
 	host := parseHost(envelope)
-	tags := parseTags(envelope, p.Environment, p.DeploymentUUIDRegex, p.JobPartitionUUIDRegex)
-	tags = append(tags, p.CustomTags...)
+	envTags := parseTags(envelope, p.Environment, p.DeploymentUUIDRegex, p.JobPartitionUUIDRegex)
+	envTags = append(envTags, p.CustomTags...)
+
+	// When BOSH tags are enabled, extract metadata from the envelope and
+	// generate tags + hostname matching the datadog-agent-boshrelease behavior.
+	// This is needed for CloudPrem where Datadog's post-ingest processing is absent.
+	boshCfg := config.NozzleConfig.BoshTagsConfig
+	if boshCfg.Enabled {
+		meta := tags.ExtractMetadataFromEnvelope(envelope)
+		envTags = append(envTags, tags.GenerateBoshTags(boshCfg, meta)...)
+		host = tags.GenerateHostname(boshCfg, meta)
+	}
 
 	logValue.Hostname = host
-	logValue.Tags = strings.Join(tags, ",")
+	logValue.Tags = strings.Join(envTags, ",")
 	logValue.Message = string(envelope.GetLog().Payload)
 
 	return logValue, nil

--- a/internal/tags/bosh_tags.go
+++ b/internal/tags/bosh_tags.go
@@ -9,7 +9,7 @@ import (
 
 // BoshTagsConfig controls BOSH tag generation and hostname resolution
 type BoshTagsConfig struct {
-	Enabled                    bool `json:"BoshTags"`
+	Enabled                    bool `json:"Enabled"`
 	FriendlyHostname           bool `json:"FriendlyHostname"`
 	UniqueFriendlyHostname     bool `json:"UniqueFriendlyHostname"`
 	FriendlyHostnameAppendGUID bool `json:"FriendlyHostnameAppendGuid"`

--- a/internal/tags/bosh_tags.go
+++ b/internal/tags/bosh_tags.go
@@ -9,11 +9,11 @@ import (
 
 // BoshTagsConfig controls BOSH tag generation and hostname resolution
 type BoshTagsConfig struct {
-	Enabled                    bool `json:"bosh_tags"`
-	FriendlyHostname           bool `json:"friendly_hostname"`
-	UniqueFriendlyHostname     bool `json:"unique_friendly_hostname"`
-	FriendlyHostnameAppendGUID bool `json:"friendly_hostname_append_guid"`
-	UseUUIDHostname            bool `json:"use_uuid_hostname"`
+	Enabled                    bool `json:"BoshTags"`
+	FriendlyHostname           bool `json:"FriendlyHostname"`
+	UniqueFriendlyHostname     bool `json:"UniqueFriendlyHostname"`
+	FriendlyHostnameAppendGUID bool `json:"FriendlyHostnameAppendGuid"`
+	UseUUIDHostname            bool `json:"UseUuidHostname"`
 }
 
 // EnvelopeMetadata holds BOSH metadata extracted from loggregator envelopes

--- a/internal/tags/bosh_tags.go
+++ b/internal/tags/bosh_tags.go
@@ -1,0 +1,110 @@
+package tags
+
+import (
+	"fmt"
+	"strings"
+
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+)
+
+// BoshTagsConfig controls BOSH tag generation and hostname resolution
+type BoshTagsConfig struct {
+	Enabled                    bool `json:"bosh_tags"`
+	FriendlyHostname           bool `json:"friendly_hostname"`
+	UniqueFriendlyHostname     bool `json:"unique_friendly_hostname"`
+	FriendlyHostnameAppendGUID bool `json:"friendly_hostname_append_guid"`
+	UseUUIDHostname            bool `json:"use_uuid_hostname"`
+}
+
+// EnvelopeMetadata holds BOSH metadata extracted from loggregator envelopes
+type EnvelopeMetadata struct {
+	ID         string // VM GUID (envelope "index" tag)
+	Job        string // job name like "diego-cell"
+	Index      string // instance index
+	AZ         string // availability zone
+	Deployment string // BOSH deployment name
+	Address    string // DNS address
+	IP         string // IP address
+}
+
+// ExtractMetadataFromEnvelope pulls BOSH metadata from a loggregator envelope
+func ExtractMetadataFromEnvelope(envelope *loggregator_v2.Envelope) EnvelopeMetadata {
+	t := envelope.GetTags()
+	return EnvelopeMetadata{
+		ID:         t["index"],
+		Job:        t["job"],
+		Index:      envelope.GetInstanceId(),
+		AZ:         t["az"],
+		Deployment: t["deployment"],
+		Address:    t["address"],
+		IP:         t["ip"],
+	}
+}
+
+// GenerateBoshTags creates tags matching the datadog-agent-boshrelease behavior
+// https://github.com/DataDog/datadog-agent-boshrelease/blob/master/jobs/dd-agent/templates/config/datadog.yaml.erb#L133-L159
+func GenerateBoshTags(config BoshTagsConfig, meta EnvelopeMetadata) []string {
+	var tags []string
+
+	if config.Enabled {
+		if meta.ID != "" {
+			tags = append(tags, fmt.Sprintf("bosh_id:%s", meta.ID))
+		}
+		if meta.Job != "" {
+			tags = append(tags, fmt.Sprintf("bosh_job:%s", meta.Job))
+			tags = append(tags, fmt.Sprintf("bosh_name:%s", meta.Job))
+		}
+		if meta.Index != "" {
+			tags = append(tags, fmt.Sprintf("bosh_index:%s", meta.Index))
+		}
+		if meta.AZ != "" {
+			tags = append(tags, fmt.Sprintf("bosh_az:%s", meta.AZ))
+		}
+		if meta.Deployment != "" {
+			tags = append(tags, fmt.Sprintf("bosh_deployment:%s", meta.Deployment))
+		}
+		if meta.Address != "" {
+			tags = append(tags, fmt.Sprintf("bosh_address:%s", meta.Address))
+		}
+		if meta.IP != "" {
+			tags = append(tags, fmt.Sprintf("bosh_ip:%s", meta.IP))
+		}
+	}
+
+	// These are always added (not optional per the Ruby code)
+	if meta.Deployment != "" {
+		if !config.Enabled {
+			tags = append(tags, fmt.Sprintf("bosh_deployment:%s", meta.Deployment))
+		}
+		tags = append(tags, fmt.Sprintf("deployment:%s", meta.Deployment))
+	}
+
+	return tags
+}
+
+// GenerateHostname creates hostname matching the datadog-agent-boshrelease behavior
+// https://github.com/DataDog/datadog-agent-boshrelease/blob/master/jobs/dd-agent/templates/config/datadog.yaml.erb#L100-L124
+func GenerateHostname(config BoshTagsConfig, meta EnvelopeMetadata) string {
+	var hostname string
+
+	if config.UseUUIDHostname && meta.ID != "" {
+		hostname = meta.ID
+	} else if config.FriendlyHostname {
+		hostname = fmt.Sprintf("%s-%s", meta.Job, meta.Index)
+
+		if config.UniqueFriendlyHostname {
+			hostname = fmt.Sprintf("%s-%s", hostname, meta.Deployment)
+		}
+		if config.FriendlyHostnameAppendGUID && meta.ID != "" {
+			hostname = fmt.Sprintf("%s-%s", hostname, meta.ID)
+		}
+	} else {
+		// Fallback to job-index
+		hostname = fmt.Sprintf("%s-%s", meta.Job, meta.Index)
+	}
+
+	// Replace underscores with hyphens (matching Ruby: hostname.tr('_', '-'))
+	hostname = strings.ReplaceAll(hostname, "_", "-")
+
+	return hostname
+}

--- a/internal/tags/bosh_tags_test.go
+++ b/internal/tags/bosh_tags_test.go
@@ -1,0 +1,178 @@
+package tags
+
+import (
+	"testing"
+
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBoshTags(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Bosh Tags Suite")
+}
+
+var _ = Describe("GenerateBoshTags", func() {
+	var (
+		cfg  BoshTagsConfig
+		meta EnvelopeMetadata
+	)
+
+	BeforeEach(func() {
+		cfg = BoshTagsConfig{}
+		meta = EnvelopeMetadata{
+			ID:         "abc-123",
+			Job:        "diego-cell",
+			Index:      "0",
+			AZ:         "z1",
+			Deployment: "cf-prod",
+			Address:    "10.0.0.1",
+			IP:         "10.0.0.2",
+		}
+	})
+
+	It("returns only mandatory tags when disabled", func() {
+		cfg.Enabled = false
+		tags := GenerateBoshTags(cfg, meta)
+
+		Expect(tags).To(ContainElement("bosh_deployment:cf-prod"))
+		Expect(tags).To(ContainElement("deployment:cf-prod"))
+		Expect(tags).NotTo(ContainElement("bosh_id:abc-123"))
+		Expect(tags).NotTo(ContainElement("bosh_job:diego-cell"))
+	})
+
+	It("generates all prefixed tags when enabled", func() {
+		cfg.Enabled = true
+		tags := GenerateBoshTags(cfg, meta)
+
+		Expect(tags).To(ContainElement("bosh_id:abc-123"))
+		Expect(tags).To(ContainElement("bosh_job:diego-cell"))
+		Expect(tags).To(ContainElement("bosh_name:diego-cell"))
+		Expect(tags).To(ContainElement("bosh_index:0"))
+		Expect(tags).To(ContainElement("bosh_az:z1"))
+		Expect(tags).To(ContainElement("bosh_deployment:cf-prod"))
+		// Always-added mandatory tags
+		Expect(tags).To(ContainElement("deployment:cf-prod"))
+	})
+
+	It("always includes address and IP tags when enabled", func() {
+		cfg.Enabled = true
+		tags := GenerateBoshTags(cfg, meta)
+		Expect(tags).To(ContainElement("bosh_address:10.0.0.1"))
+		Expect(tags).To(ContainElement("bosh_ip:10.0.0.2"))
+	})
+
+	It("skips tags for empty metadata fields", func() {
+		cfg.Enabled = true
+		meta.AZ = ""
+		meta.Address = ""
+		meta.IP = ""
+		tags := GenerateBoshTags(cfg, meta)
+		Expect(tags).NotTo(ContainElement("bosh_az:"))
+		Expect(tags).NotTo(ContainElement("bosh_address:"))
+		Expect(tags).NotTo(ContainElement("bosh_ip:"))
+	})
+
+	It("does not duplicate bosh_deployment when enabled", func() {
+		cfg.Enabled = true
+		tags := GenerateBoshTags(cfg, meta)
+		count := 0
+		for _, t := range tags {
+			if t == "bosh_deployment:cf-prod" {
+				count++
+			}
+		}
+		Expect(count).To(Equal(1))
+	})
+})
+
+var _ = Describe("GenerateHostname", func() {
+	var (
+		cfg  BoshTagsConfig
+		meta EnvelopeMetadata
+	)
+
+	BeforeEach(func() {
+		cfg = BoshTagsConfig{}
+		meta = EnvelopeMetadata{
+			ID:         "abc-123",
+			Job:        "diego-cell",
+			Index:      "0",
+			Deployment: "cf-prod",
+		}
+	})
+
+	It("uses UUID hostname when configured", func() {
+		cfg.UseUUIDHostname = true
+		Expect(GenerateHostname(cfg, meta)).To(Equal("abc-123"))
+	})
+
+	It("returns friendly hostname (job-index)", func() {
+		cfg.FriendlyHostname = true
+		Expect(GenerateHostname(cfg, meta)).To(Equal("diego-cell-0"))
+	})
+
+	It("appends deployment for unique friendly hostname", func() {
+		cfg.FriendlyHostname = true
+		cfg.UniqueFriendlyHostname = true
+		Expect(GenerateHostname(cfg, meta)).To(Equal("diego-cell-0-cf-prod"))
+	})
+
+	It("appends VM GUID when configured", func() {
+		cfg.FriendlyHostname = true
+		cfg.FriendlyHostnameAppendGUID = true
+		Expect(GenerateHostname(cfg, meta)).To(Equal("diego-cell-0-abc-123"))
+	})
+
+	It("falls back to job-index when nothing configured", func() {
+		Expect(GenerateHostname(cfg, meta)).To(Equal("diego-cell-0"))
+	})
+
+	It("replaces underscores in friendly hostnames", func() {
+		cfg.FriendlyHostname = true
+		meta.Job = "diego_cell"
+		Expect(GenerateHostname(cfg, meta)).To(Equal("diego-cell-0"))
+	})
+})
+
+var _ = Describe("ExtractMetadataFromEnvelope", func() {
+	It("extracts all fields from envelope tags", func() {
+		envelope := &loggregator_v2.Envelope{
+			InstanceId: "42",
+			Tags: map[string]string{
+				"index":      "vm-guid-123",
+				"job":        "diego-cell",
+				"az":         "z1",
+				"deployment": "cf-prod",
+				"address":    "10.0.0.1",
+				"ip":         "10.0.0.2",
+			},
+		}
+
+		meta := ExtractMetadataFromEnvelope(envelope)
+
+		Expect(meta.ID).To(Equal("vm-guid-123"))
+		Expect(meta.Job).To(Equal("diego-cell"))
+		Expect(meta.Index).To(Equal("42"))
+		Expect(meta.AZ).To(Equal("z1"))
+		Expect(meta.Deployment).To(Equal("cf-prod"))
+		Expect(meta.Address).To(Equal("10.0.0.1"))
+		Expect(meta.IP).To(Equal("10.0.0.2"))
+	})
+
+	It("handles missing tags gracefully", func() {
+		envelope := &loggregator_v2.Envelope{
+			Tags: map[string]string{
+				"job": "router",
+			},
+		}
+
+		meta := ExtractMetadataFromEnvelope(envelope)
+
+		Expect(meta.ID).To(Equal(""))
+		Expect(meta.Job).To(Equal("router"))
+		Expect(meta.Deployment).To(Equal(""))
+	})
+})
+


### PR DESCRIPTION
When sending logs to Datadog BYOC (CloudPrem), the post-ingest enrichment that normally adds host tags and hostname is absent. This adds a new internal/tags package with pure functions that replicate the datadog-agent-boshrelease behavior:

- ExtractMetadataFromEnvelope: pulls BOSH metadata from envelope tags
- GenerateBoshTags: generates bosh_* prefixed tags + mandatory deployment tags
- GenerateHostname: builds hostname from job-index with optional suffixes

The feature is gated behind BoshTagsConfig.Enabled (default: false) and only affects log processing in ParseLog().

